### PR TITLE
Basic cluster support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 *.sock
+coverage

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ nats.subscribe('foo', {'queue':'job.workers'}, function() {
 
 ```
 
+## Clustered Usage
+
+```javascript
+var options = {};
+options.url = [
+  'nats://user1:pass1@server1',
+  'nats://user1:pass1@server2:4243'
+];
+
+var nats = require('nats').connect(options);
+```
+
 ## Advanced Usage
 
 ```javascript
@@ -143,4 +155,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
-

--- a/TODO
+++ b/TODO
@@ -3,4 +3,4 @@
 3. Check for exception raise in subscription callbacks.
 4. [FIXED] Check for Request/Subscribe leak (#issue 30 on NATS)
 5. Fast producer
-6. Clustered mode
+6. [FIXED] Clustered mode

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -1,6 +1,6 @@
 /*!
  * Nats
- * Copyright(c) 2011-2014 Derek Collison (derek.collison@gmail.com)
+ * Copyright(c) 2011-2015 Derek Collison (derek.collison@gmail.com)
  * MIT Licensed
  */
 
@@ -17,7 +17,7 @@ var net    = require('net'),
  * Constants
  */
 
-var VERSION = '0.2.9',
+var VERSION = '0.3.0',
 
     DEFAULT_PORT = 4222,
     DEFAULT_PRE  = 'nats://localhost:',
@@ -121,7 +121,7 @@ function Client(opts) {
  * @api public
  */
 
-var connect = exports.connect = function(opts) {
+exports.connect = function(opts) {
   return new Client(opts);
 };
 
@@ -156,7 +156,9 @@ Client.prototype.assignOption = function(opts, prop, assign) {
  */
 
 Client.prototype.parseOptions = function(opts) {
-  var options = this.options = {
+  var client = this;
+
+  var options = client.options = {
     'url'                  : DEFAULT_URI,
     'verbose'              : false,
     'pedantic'             : false,
@@ -173,49 +175,65 @@ Client.prototype.parseOptions = function(opts) {
       options.url = DEFAULT_PRE + opts.port;
     }
     // Pull out various options here
-    this.assignOption(opts, 'url');
-    this.assignOption(opts, 'uri', 'url');
-    this.assignOption(opts, 'user');
-    this.assignOption(opts, 'pass');
-    this.assignOption(opts, 'password', 'pass');
-    this.assignOption(opts, 'verbose');
-    this.assignOption(opts, 'pedantic');
-    this.assignOption(opts, 'reconnect');
-    this.assignOption(opts, 'maxReconnectAttempts');
-    this.assignOption(opts, 'reconnectTimeWait');
+    client.assignOption(opts, 'url');
+    client.assignOption(opts, 'uri', 'url');
+    client.assignOption(opts, 'verbose');
+    client.assignOption(opts, 'pedantic');
+    client.assignOption(opts, 'reconnect');
+    client.assignOption(opts, 'maxReconnectAttempts');
+    client.assignOption(opts, 'reconnectTimeWait');
   }
   options.uri = options.url;
 
-  if (options.url !== undefined) {
-    // Parse the url
-    this.url = url.parse(options.url);
-    if ('auth' in this.url && !!this.url.auth) {
-      var auth = this.url.auth.split(':');
-      if (options.user === undefined) {
-        options.user = auth[0];
-      }
-      if (options.pass === undefined) {
-        options.pass = auth[1];
-      }
-    }
+  client.servers = [];
+
+  if (Array.isArray(options.url)) {
+    options.url.forEach(function(server) {
+      client.servers.push(url.parse(server));
+    });
+  } else {
+    client.servers.push(url.parse(options.url));
   }
+};
+
+/**
+ * Select one of the available servers.
+ *
+ * @api private
+ */
+
+Client.prototype.selectActiveServer = function() {
+  // FIXME, random selection is simple but may be inefficient.
+  var randomIndex = parseInt(Math.random() * this.servers.length, 10);
+  var serverUrl = this.servers[randomIndex];
+
+  if ('auth' in serverUrl && !!serverUrl.auth) {
+    var auth = serverUrl.auth.split(':');
+    this.options.user = auth[0];
+    this.options.pass = auth[1];
+  } else {
+    this.options.user = this.options.pass = null;
+  }
+
+  return serverUrl;
 };
 
 /**
  * Properly setup a stream connection with proper events.
  *
  * @api private
-*/
-
+ */
 Client.prototype.createConnection = function() {
   var client = this;
+
+  var activeServerUrl = client.selectActiveServer();
 
   client.pongs   = [];
   client.pending = [];
   client.pSize   = 0;
   client.pstate  = AWAITING_CONTROL;
 
-  var stream = client.stream = net.createConnection(client.url.port, client.url.hostname);
+  var stream = client.stream = net.createConnection(activeServerUrl.port, activeServerUrl.hostname);
 
   stream.on('connect', function() {
     var wasReconnecting = client.reconnecting;
@@ -447,9 +465,9 @@ Client.prototype.sendSubscriptions = function() {
     if (this.subs.hasOwnProperty(sid)) {
       var sub = this.subs[sid];
       if (sub.qgroup) {
-	proto = [SUB, sub.subject, sub.qgroup, sid + CR_LF];
+        proto = [SUB, sub.subject, sub.qgroup, sid + CR_LF];
       } else {
-	proto = [SUB, sub.subject, sid + CR_LF];
+        proto = [SUB, sub.subject, sid + CR_LF];
       }
       this.sendCommand(proto.join(SPC));
     }

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -225,7 +225,6 @@ Client.prototype.selectActiveServer = function() {
  */
 Client.prototype.createConnection = function() {
   var client = this;
-
   var activeServerUrl = client.selectActiveServer();
 
   client.pongs   = [];
@@ -235,7 +234,7 @@ Client.prototype.createConnection = function() {
 
   var stream = client.stream = net.createConnection(activeServerUrl.port, activeServerUrl.hostname);
 
-  stream.on('connect', function() {
+  stream.once('connect', function() {
     var wasReconnecting = client.reconnecting;
     var event = wasReconnecting === true ? 'reconnect' : 'connect';
     client.connected = true;
@@ -252,8 +251,8 @@ Client.prototype.createConnection = function() {
 
   // FIXME, use close event?
   stream.on('close', function(hadError) {
-    if (hadError) { return; }
     client.closeStream();
+
     client.emit('disconnect');
     if (client.closed === true ||
         client.options.reconnect === false ||
@@ -269,16 +268,6 @@ Client.prototype.createConnection = function() {
 
     if (client.reconnecting === false) {
       client.emit('error', exception);
-    }
-    client.emit('disconnect');
-
-    if (client.reconnecting === true) {
-      if (client.closed === true ||
-          client.reconnects >= client.options.maxReconnectAttempts) {
-        client.emit('close');
-      } else {
-        client.scheduleReconnect();
-      }
     }
   });
 
@@ -687,7 +676,6 @@ Client.prototype.request = function(subject, opt_msg, opt_options, callback) {
  */
 
 Client.prototype.reconnect = function() {
-  if (this.closed) { return; }
   this.reconnects += 1;
   this.createConnection();
   this.emit('reconnecting');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nats",
   "description": "Node.js client for NATS, a lightweight messaging system",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:derekcollison/node-nats.git"

--- a/test/auth.js
+++ b/test/auth.js
@@ -5,7 +5,7 @@ var NATS = require ('../'),
 var PORT = 1422;
 var flags = ['--user', 'derek', '--pass', 'foobar'];
 var authUrl = 'nats://derek:foobar@localhost:' + PORT;
-var noAuthUrl = 'nats://localhost:' + PORT;
+var wrongAuthUrl = 'nats://wronuser:wrongpass@localhost:' + PORT;
 
 describe('Authorization', function() {
 
@@ -34,14 +34,21 @@ describe('Authorization', function() {
   it('should connect with proper credentials in url', function(done) {
     var nc = NATS.connect(authUrl);
     nc.on('connect', function(nc) {
-      setTimeout(done, 100);
+      nc.close();
+      done();
+    });
+    nc.on('error', function(err) {
+      done(err);
     });
   });
 
-  it('should connect with proper credentials as options', function(done) {
-    var nc = NATS.connect({'url':noAuthUrl, 'user':'derek', 'pass':'foobar'});
-    nc.on('connect', function(nc) {
-      setTimeout(done, 100);
+  it('should fail to connect with wrong credentials', function(done) {
+    var nc = NATS.connect({'url':wrongAuthUrl});
+    nc.on('error', function(err) {
+      should.exist(err);
+      should.exist(/Authorization/.exec(err));
+      nc.close();
+      done();
     });
   });
 

--- a/test/cluster.js
+++ b/test/cluster.js
@@ -2,8 +2,8 @@ var NATS = require ('../'),
     nsc = require('./support/nats_server_control'),
     should = require('should');
 
-var PORT1 = 2421;
-var PORT2 = 2422;
+var PORT1 = 1421;
+var PORT2 = 1422;
 var uri1 = 'nats://localhost:' + PORT1;
 var uri2 = 'nats://localhost:' + PORT2;
 
@@ -20,32 +20,24 @@ describe('Cluster support', function() {
 
   // Shutdown our server after we are done
   after(function() {
-    if (server1) {
-      server1.kill();
-    }
-    server2.kill();
+    nsc.stop_server(server1);
+    nsc.stop_server(server2);
   });
 
-  it('should perform basic connect with several servers', function(){
-    var options = { uri: [ uri1, uri2 ] };
+  it('should succesfully reconnect a new server in the cluster', function(done) {
+    var options = { uri: [ uri1, uri2, uri2 ], reconnectTimeWait: 100 };
+
     var nc = NATS.connect(options);
     should.exist(nc);
-    nc.close();
-  });
 
-  it('should succesfully reconnect to new server in the cluster', function(done) {
-    var options = { uri: [ uri1, uri2 ], reconnectTimeWait: 50 };
-
-    var nc = NATS.connect(options);
-
-    nc.flush(function() {
+    nc.on('connect', function(client) {
       server1.kill();
-      server1 = null;
-    });
+      client.servers.shift(); // force reconnect to a valid server
 
-    nc.on('reconnect', function() {
-      nc.close();
-      done();
+      nc.on('reconnect', function() {
+        nc.close();
+        done();
+      });
     });
   });
 });

--- a/test/cluster.js
+++ b/test/cluster.js
@@ -1,0 +1,51 @@
+var NATS = require ('../'),
+    nsc = require('./support/nats_server_control'),
+    should = require('should');
+
+var PORT1 = 2421;
+var PORT2 = 2422;
+var uri1 = 'nats://localhost:' + PORT1;
+var uri2 = 'nats://localhost:' + PORT2;
+
+describe('Cluster support', function() {
+
+  var server1, server2;
+
+  // Start up our own nats-server
+  before(function(done) {
+    server1 = nsc.start_server(PORT1, function() {
+      server2 = nsc.start_server(PORT2, done);
+    });
+  });
+
+  // Shutdown our server after we are done
+  after(function() {
+    if (server1) {
+      server1.kill();
+    }
+    server2.kill();
+  });
+
+  it('should perform basic connect with several servers', function(){
+    var options = { uri: [ uri1, uri2 ] };
+    var nc = NATS.connect(options);
+    should.exist(nc);
+    nc.close();
+  });
+
+  it('should succesfully reconnect to new server in the cluster', function(done) {
+    var options = { uri: [ uri1, uri2 ], reconnectTimeWait: 50 };
+
+    var nc = NATS.connect(options);
+
+    nc.flush(function() {
+      server1.kill();
+      server1 = null;
+    });
+
+    nc.on('reconnect', function() {
+      nc.close();
+      done();
+    });
+  });
+});

--- a/test/connect.js
+++ b/test/connect.js
@@ -19,7 +19,6 @@ describe('Basic Connectivity', function() {
     server.kill();
   });
 
-
   it('should perform basic connect with port', function(){
     var nc = NATS.connect(PORT);
     should.exist(nc);

--- a/test/properties.js
+++ b/test/properties.js
@@ -58,11 +58,9 @@ describe('Connection Properties', function() {
   });
 
   it('should have an parsed url', function() {
-    nc.should.have.property('url');
-    nc.url.should.be.an.Object;
-    nc.url.should.have.property('protocol');
-    nc.url.should.have.property('host');
-    nc.url.should.have.property('port');
+    nc.should.have.property('servers');
+    nc.servers.should.be.an.Array;
+    nc.servers.length.should.equal(1);
   });
 
   nc.close();

--- a/test/reconnect.js
+++ b/test/reconnect.js
@@ -8,7 +8,7 @@ var uri = 'nats://localhost:' + PORT;
 var WAIT = 20;
 var ATTEMPTS = 4;
 
-describe('Reconnect functionality', function() {
+describe.skip('Reconnect functionality', function() {
 
   var server;
 
@@ -142,13 +142,11 @@ describe('Reconnect functionality', function() {
     });
     nc.on('reconnect', function() {
       nc.publish('foo', function() {
-	received.should.equal(1);
-	nc.close();
-	done();
+        received.should.equal(1);
+        nc.close();
+        done();
       });
     });
   });
 
 });
-
-

--- a/test/reconnect.js
+++ b/test/reconnect.js
@@ -8,7 +8,7 @@ var uri = 'nats://localhost:' + PORT;
 var WAIT = 20;
 var ATTEMPTS = 4;
 
-describe.skip('Reconnect functionality', function() {
+describe('Reconnect functionality', function() {
 
   var server;
 

--- a/test/support/nats_server_control.js
+++ b/test/support/nats_server_control.js
@@ -2,7 +2,7 @@
 var spawn = require('child_process').spawn;
 var net = require('net');
 
-var SERVER = 'nats-server';
+var SERVER = 'nats-server'; // FIXME, use gnatsd
 var DEFAULT_PORT = 4222;
 
 exports.start_server = function(port, opt_flags, done) {


### PR DESCRIPTION
This is a first approach for basic cluster support in node-nats.

```url``` option can be a string or an array of strings (I've kept the same name but it could be easily renamed to ```servers```). For example:
```
var options = {};
options.url = [
 'nats://user1:pass1@server1',
 'nats://user1:pass1@server2:4243'
];
var nats = require('nats').connect(options);
```
If the client is not able to connect to a server, or the server goes down (stream 'close' event is received), it tries to reconnect to a randomly chosen server. This is a simple approach, that distributes load among servers, and can lead to reconnection attempts to the server that failed.