### PR TITLE
noDelay and WebSocket

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -174,6 +174,7 @@ Client.prototype.parseOptions = function(opts) {
     'verbose'              : false,
     'pedantic'             : false,
     'reconnect'            : true,
+    'noDelay'              : false,
     'maxReconnectAttempts' : DEFAULT_MAX_RECONNECT_ATTEMPTS,
     'reconnectTimeWait'    : DEFAULT_RECONNECT_TIME_WAIT,
     'encoding'             : 'utf8'
@@ -198,6 +199,7 @@ Client.prototype.parseOptions = function(opts) {
     this.assignOption(opts, 'verbose');
     this.assignOption(opts, 'pedantic');
     this.assignOption(opts, 'reconnect');
+    this.assignOption(opts, 'noDelay');
     this.assignOption(opts, 'maxReconnectAttempts');
     this.assignOption(opts, 'reconnectTimeWait');
     this.assignOption(opts, 'servers');
@@ -298,6 +300,8 @@ Client.prototype.createConnection = function() {
   client.selectServer();
 
   var stream = client.stream = net.createConnection(client.url.port, client.url.hostname);
+
+  stream.setNoDelay(client.options.noDelay)
 
   stream.on('connect', function() {
     var wasReconnecting = client.reconnecting;

--- a/lib/net.js
+++ b/lib/net.js
@@ -34,6 +34,9 @@ Socket.prototype.write = function(data) {
   this.ws.send(data)
 }
 
+Socket.prototype.setNoDelay = function() {
+}
+
 exports.createConnection = function(port, host) {
   return new Socket('ws://' + host + ':' + port)
 }

--- a/lib/net.js
+++ b/lib/net.js
@@ -1,0 +1,39 @@
+var util = require('util')
+var EventEmitter = require('events').EventEmitter
+
+function Socket(url) {
+  EventEmitter.call(this)
+  var self = this
+  var ws = this.ws = new WebSocket(url)
+  ws.binaryType = 'arraybuffer'
+  // connect, close, error, data
+  ws.onopen = function() {
+    self.emit('connect')
+  }
+  ws.onclose = function() {
+    self.emit('close')
+  }
+  ws.onerror = function(err) {
+    self.emit('error', err)
+  }
+  ws.onmessage = function(message) {
+    self.emit('data', new Buffer(message.data))
+  }
+}
+util.inherits(Socket, EventEmitter)
+
+Socket.prototype.end = function() {
+  this.ws.close()
+}
+
+Socket.prototype.destroy = function() {
+  this.ws.close()
+}
+
+Socket.prototype.write = function(data) {
+  this.ws.send(data)
+}
+
+exports.createConnection = function(port, host) {
+  return new Socket('ws://' + host + ':' + port)
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   },
   "contributors": [],
   "main": "./index.js",
+  "browser": {
+    "net": "./lib/net.js"
+  },
   "scripts": {
     "lint": "jshint --reporter node_modules/jshint-stylish lib/*.js test/*.js test/support/*.js examples/*.js",
     "depcheck": "dependency-check . lib/*",
@@ -39,7 +42,9 @@
   "engines": {
     "node": ">= 0.10.x"
   },
-  "dependencies": {},
+  "dependencies": {
+    "events": "^1.0.2"
+  },
   "devDependencies": {
     "jshint": "2.8.x",
     "jshint-stylish": "2.0.x",


### PR DESCRIPTION
Assuming the API for the future WebSocket support in NATS looks the same I see no reason why not add web socket support into the clients. Until the server supports web sockets users can use a proxy server.

This code requires that one uses either browserify or webpack to get the required "Buffer" polyfill. Alternatively one can add a dependency to the "buffer" npm package.