### PR TITLE
Allow user to configure client to attempt unlimited reconnects

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -321,7 +321,7 @@ Client.prototype.createConnection = function() {
     client.emit('disconnect');
     if (client.closed === true ||
         client.options.reconnect === false ||
-        client.reconnects >= client.options.maxReconnectAttempts) {
+        ((client.reconnects >= client.options.maxReconnectAttempts) && client.options.maxReconnectAttempts !== -1)) {
       client.emit('close');
     } else {
       client.scheduleReconnect();


### PR DESCRIPTION
We had an issue today where restarting our gnatsd server caused all of our clients eventually to give up trying to reconnect. Eventually, we had to restart many different processes across several different servers. It may be useful or desirable to allow users to configure their clients to make unlimited reconnect attempts (rather than some arbitrary large number, like 1000 or 10000).

If that is something that might be desired, adding an additional conditional to the ``close`` event listener would solve the issue. This way, a user would be able to pass in a ``maxReconnectAttempts`` value of ``-1`` in the client options to indicate that the client should attempt to reconnect indefinitely. (Some other value would of course work just as well...)