### PR TITLE
Unwrap `stream.resume()`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 sudo: false
 
 node_js:
+  - "0.10"
   - "0.12"
   - "5.1"
   - "5.2"

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -595,9 +595,7 @@ Client.prototype.processInbound = function() {
   var start;
 
   // unpause if needed.
-  if (client.stream.isPaused()) {
-    client.stream.resume();
-  }
+  client.stream.resume();
 
   /* jshint -W083 */
 


### PR DESCRIPTION
As `isPaused()` is already implied by `resume()`, its call is
extraneous.  This wouldn't be a problem, but this breaks compatibility
with NodeJS 0.10.x, which, while old, is still in the ecosystem.

Fixes #49 