### PR TITLE
Add callback to sendCommand/flushPending

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -518,13 +518,13 @@ Client.prototype.closeStream = function() {
  * @api private
  */
 
-Client.prototype.flushPending = function() {
+Client.prototype.flushPending = function(cb) {
   if (this.connected === false ||
       this.pending === null ||
       this.pending.length === 0 ||
       this.infoReceived !== true) { return; }
 
-  this.stream.write(this.pending.join(EMPTY));
+  this.stream.write(this.pending.join(EMPTY),cb);
   this.pending = [];
   this.pSize   = 0;
 };
@@ -535,11 +535,14 @@ Client.prototype.flushPending = function() {
  * @api private
  */
 
-Client.prototype.sendCommand = function(cmd) {
+Client.prototype.sendCommand = function(cmd,cb) {
   // Buffer to cut down on system calls, increase throughput.
   // When receive gets faster, should make this Buffer based..
 
-  if (this.closed || this.pending === null) { return; }
+  if (this.closed || this.pending === null) {
+     if( typeof cb === 'function') { cb('No connection'); }
+     return;
+  }
 
   this.pending.push(cmd);
   this.pSize += Buffer.byteLength(cmd);
@@ -549,13 +552,14 @@ Client.prototype.sendCommand = function(cmd) {
     if (this.pending.length === 1) {
       var self = this;
       setImmediate(function() {
-        self.flushPending();
+        self.flushPending(cb);
       });
     } else if (this.pSize > FLUSH_THRESHOLD) {
       // Flush in place when threshold reached..
-      this.flushPending();
+      this.flushPending(cb);
     }
   }
+  return;
 };
 
 /**
@@ -824,11 +828,7 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
   } else {
     psub = 'PUB ' + subject + SPC + opt_reply + SPC;
   }
-  this.sendCommand(psub + Buffer.byteLength(msg) + CR_LF + msg + CR_LF);
-
-  if (opt_callback !== undefined) {
-    this.flush(opt_callback);
-  }
+  this.sendCommand(psub + Buffer.byteLength(msg) + CR_LF + msg + CR_LF, opt_callback);
 };
 
 /**

--- a/test/basics.js
+++ b/test/basics.js
@@ -198,7 +198,9 @@ describe('Basics', function() {
 
   it('should do callback after publish is flushed', function(done) {
     var nc = NATS.connect(PORT);
-    nc.publish('foo', done);
+    nc.on('connect',function() {
+       nc.publish('foo', done);
+    });
   });
 
   it('should do callback after flush', function(done) {
@@ -226,11 +228,12 @@ describe('Basics', function() {
 
     nc.publish('foo');
     nc.publish('foo');
-    nc.publish('foo', function() {
+    nc.publish('foo');
+    setTimeout(function() {
       received.should.equal(expected);
       nc.close();
       done();
-    });
+    },10);
   });
 
   it('should pass sid properly to a message callback if requested', function(done) {

--- a/test/queues.js
+++ b/test/queues.js
@@ -27,12 +27,13 @@ describe('Queues', function() {
     nc.subscribe('foo', {'queue':'myqueue'}, function() {
       received += 1;
     });
-    nc.publish('foo', function() {
+    nc.publish('foo');
+    setTimeout(function() {
       should.exists(received);
       received.should.equal(1);
       nc.close();
       done();
-    });
+    },10);
   });
 
   it('should deliver a message to only one member of a queue group', function(done) {
@@ -42,11 +43,12 @@ describe('Queues', function() {
     for (var i=0; i<5; i++) {
       nc.subscribe('foo', {'queue':'myqueue'}, cb);
     }
-    nc.publish('foo', function() {
+    nc.publish('foo');
+    setTimeout(function() {
       received.should.equal(1);
       nc.close();
       done();
-    });
+    },10);
   });
 
   it('should allow queue subscribers and normal subscribers to work together', function(done) {
@@ -56,11 +58,11 @@ describe('Queues', function() {
     nc.subscribe('foo', function() { received += 1; });
     nc.publish('foo');
     nc.publish('foo');
-    nc.flush(function() {
+    setTimeout(function() {
       received.should.equal(4);
       nc.close();
       done();
-    });
+    },10);
   });
 
   it('should spread messages out equally (given random)', function(done) {
@@ -96,11 +98,12 @@ describe('Queues', function() {
     nc.subscribe('foo.bar', {'queue':'wcqueue'}, function() { received += 1; });
     nc.subscribe('foo.*', {'queue':'wcqueue'}, function() { received += 1; });
     nc.subscribe('foo.>', {'queue':'wcqueue'}, function() { received += 1; });
-    nc.publish('foo.bar', function() {
+    nc.publish('foo.bar');
+    setTimeout(function() {
       received.should.equal(1);
       nc.close();
       done();
-    });
+    },10);
   });
 
   it('should deliver to multiple queue groups', function(done) {

--- a/test/reconnect.js
+++ b/test/reconnect.js
@@ -233,34 +233,4 @@ describe('Reconnect functionality', function() {
     });
   });
 
-  it('should not return an error to the publish callback when sending while connected', function(done) {
-    var nc = NATS.connect({'port':PORT, 'reconnectTimeWait':WAIT});
-    should.exist(nc);
-    nc.on('connect', function() {
-      nc.publish('foo', 'bar', 'reply', function(err) {
-         should(err).be.type('undefined');
-         nc.close();
-         done();
-      });
-    });
-  });
-
-  it('should return an error to the publish callback when sending after connection loss', function(done) {
-    var nc = NATS.connect({'port':PORT, 'reconnectTimeWait':WAIT});
-    var startTime;
-    should.exist(nc);
-    nc.on('connect', function() {
-      server.kill();
-      startTime = new Date();
-    });
-    nc.on('disconnect', function() {
-      nc.publish('foo', 'bar', 'reply', function(err) {
-         should(err).not.be.type('undefined');
-         nc.close();
-         done();
-      });
-      server = nsc.start_server(PORT);
-    });
-  });
-
 });

--- a/test/reconnect.js
+++ b/test/reconnect.js
@@ -233,4 +233,34 @@ describe('Reconnect functionality', function() {
     });
   });
 
+  it('should not return an error to the publish callback when sending while connected', function(done) {
+    var nc = NATS.connect({'port':PORT, 'reconnectTimeWait':WAIT});
+    should.exist(nc);
+    nc.on('connect', function() {
+      nc.publish('foo', 'bar', 'reply', function(err) {
+         should(err).be.type('undefined');
+         nc.close();
+         done();
+      });
+    });
+  });
+
+  it('should return an error to the publish callback when sending after connection loss', function(done) {
+    var nc = NATS.connect({'port':PORT, 'reconnectTimeWait':WAIT});
+    var startTime;
+    should.exist(nc);
+    nc.on('connect', function() {
+      server.kill();
+      startTime = new Date();
+    });
+    nc.on('disconnect', function() {
+      nc.publish('foo', 'bar', 'reply', function(err) {
+         should(err).not.be.type('undefined');
+         nc.close();
+         done();
+      });
+      server = nsc.start_server(PORT);
+    });
+  });
+
 });

--- a/test/reconnect.js
+++ b/test/reconnect.js
@@ -177,11 +177,12 @@ describe('Reconnect functionality', function() {
       }
     });
     nc.on('reconnect', function() {
-      nc.publish('foo', function() {
+      nc.publish('foo');
+      setTimeout(function() {
 	received.should.equal(1);
 	nc.close();
 	done();
-      });
+      },25);
     });
   });
 

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -43,7 +43,8 @@ describe('Timeout and max received events for subscriptions', function() {
       nc.timeout(sid, 50, 1, function() {
         done(new Error('Timeout improperly called'));
       });
-      nc.publish('foo', done);
+      nc.publish('foo');
+      setTimeout(done,10);
     });
   });
 


### PR DESCRIPTION
This changes the semantics of the `publish` method's callback execution
to strictly mean that the message asked to be published was sent over
the wire (or failed to have been ).

Fixes #51 -- but also significantly changes the semantics (as witnessed
by the required changes to the tests)

As a side note:  there appears to have been an oversight in the test
'Basics should do callback after publish is flushed' where the actual
publish was not being sent, but the callback was being executed by
the following ping.