### PR TITLE
fix when nats urls fail at first server,  subscription state is lost

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -336,9 +336,7 @@ Client.prototype.connectCB = function() {
   this.reconnecting = false;
   this.reconnects = 0;
   this.flushPending();
-  if (wasReconnecting) {
-    this.sendSubscriptions();
-  }
+  this.sendSubscriptions();
 
   this.wasConnected = true;
   this.currentServer.didConnect = true;

--- a/test/connect.js
+++ b/test/connect.js
@@ -58,5 +58,40 @@ describe('Basic Connectivity', function() {
       done();
     });
   });
+  
+  it('should still receive publish when some servers are invalid', function(done){
+    var natsServers = ['nats://localhost:22222', uri, 'nats://localhost:22223'];
+    var ua = NATS.connect({servers: natsServers});
+    var ub = NATS.connect({servers: natsServers});
+    var recvMsg = ""
+    ua.subscribe('topic1', function(msg, reply, subject){
+      recvMsg = msg
+    });
+    setTimeout(function(){
+      ub.publish('topic1', 'hello');
+    }, 100 * 1);
+    setTimeout(function(){
+      recvMsg.should.equal('hello');
+      done();
+    }, 100 * 2);
+  });
+
+  it('should still receive publish when some servers[noRandomize] are invalid', function(done){
+    var natsServers = ['nats://localhost:22222', uri, 'nats://localhost:22223'];
+    var ua = NATS.connect({servers: natsServers, noRandomize:true});
+    var ub = NATS.connect({servers: natsServers, noRandomize:true});
+    var recvMsg = ""
+    ua.subscribe('topic1', function(msg, reply, subject){
+      recvMsg = msg
+    });
+    setTimeout(function(){
+      ub.publish('topic1', 'hello');
+    }, 100 * 1);
+    setTimeout(function(){
+      recvMsg.should.equal('hello');
+      done();
+    }, 100 * 2);
+  });
+  
 
 });

--- a/test/connect.js
+++ b/test/connect.js
@@ -63,9 +63,9 @@ describe('Basic Connectivity', function() {
     var natsServers = ['nats://localhost:22222', uri, 'nats://localhost:22223'];
     var ua = NATS.connect({servers: natsServers});
     var ub = NATS.connect({servers: natsServers});
-    var recvMsg = ""
+    var recvMsg = "";
     ua.subscribe('topic1', function(msg, reply, subject){
-      recvMsg = msg
+      recvMsg = msg;
     });
     setTimeout(function(){
       ub.publish('topic1', 'hello');
@@ -80,9 +80,9 @@ describe('Basic Connectivity', function() {
     var natsServers = ['nats://localhost:22222', uri, 'nats://localhost:22223'];
     var ua = NATS.connect({servers: natsServers, noRandomize:true});
     var ub = NATS.connect({servers: natsServers, noRandomize:true});
-    var recvMsg = ""
+    var recvMsg = "";
     ua.subscribe('topic1', function(msg, reply, subject){
-      recvMsg = msg
+      recvMsg = msg;
     });
     setTimeout(function(){
       ub.publish('topic1', 'hello');
@@ -92,6 +92,5 @@ describe('Basic Connectivity', function() {
       done();
     }, 100 * 2);
   });
-  
 
 });


### PR DESCRIPTION
when  there are A, B, C gnatsd host, close someone, like B
then client UA, UB, UC, one of them like UC may first connect to B when noRandomize:false
UC will fail connecto B, then it reconnect to A, but UC's subs not send.