### PR TITLE
Added option to encode a JSON object before publishing a message and …

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -220,6 +220,7 @@ Client.prototype.parseOptions = function(opts) {
     this.assignOption(opts, 'name');
     this.assignOption(opts, 'client', 'name');
     this.assignOption(opts, 'yieldTime');
+    this.assignOption(opts, 'json');
   }
 
   var client = this;
@@ -234,7 +235,6 @@ Client.prototype.parseOptions = function(opts) {
   } else {
     throw new Error('Invalid Encoding:' + options.encoding);
   }
-
   // For cluster support
   client.servers = [];
 
@@ -252,6 +252,12 @@ Client.prototype.parseOptions = function(opts) {
   // Randomize if needed
   if (options.noRandomize !==  true) {
     shuffle(client.servers);
+  }
+
+  // For compatibilty with the golang client we need to use
+  // a base64 encoder when dealing with json
+  if (options.json) {
+    client.encoding = 'base64';
   }
 };
 
@@ -843,7 +849,9 @@ Client.prototype.processMsg = function() {
     }
 
     if (sub.callback) {
-      sub.callback(this.payload.msg, this.payload.reply, this.payload.subj, this.payload.sid);
+      // Create an ascii string out of the base64 msg before parsing to a json object
+      var msg = this.options.json ? JSON.parse(new Buffer(this.payload.msg, 'base64').toString('ascii')) : this.payload.msg;
+      sub.callback(msg, this.payload.reply, this.payload.subj, this.payload.sid);
     }
   }
 };
@@ -923,8 +931,10 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
   }
 
   // Need to treat sending buffers different.
+
   if (!Buffer.isBuffer(msg)) {
-    this.sendCommand(psub + Buffer.byteLength(msg) + CR_LF + msg + CR_LF);
+    var str = this.options.json ? JSON.stringify(msg) : msg;
+    this.sendCommand(psub + Buffer.byteLength(str) + CR_LF + str + CR_LF);
   } else {
     var b = new Buffer(psub.length + msg.length + (2 * CR_LF_LEN) + msg.length.toString().length);
     var len = b.write(psub + msg.length + CR_LF);

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -71,6 +71,7 @@ var VERSION = '0.5.4',
     BAD_MSG_ERR = new Error('Message can\'t be a function'),
     BAD_REPLY_ERR = new Error('Reply can\'t be a function'),
     CONN_CLOSED_ERR = new Error('Connection closed'),
+    BAD_JSON_MSG_ERR = new Error('Message should be a JSON object'),
 
     // Pedantic Mode support
     //Q_SUB = /^([^\.\*>\s]+|>$|\*)(\.([^\.\*>\s]+|>$|\*))*$/, // TODO: remove / never used
@@ -252,12 +253,6 @@ Client.prototype.parseOptions = function(opts) {
   // Randomize if needed
   if (options.noRandomize !==  true) {
     shuffle(client.servers);
-  }
-
-  // For compatibilty with the golang client we need to use
-  // a base64 encoder when dealing with json
-  if (options.json) {
-    client.encoding = 'base64';
   }
 };
 
@@ -849,8 +844,14 @@ Client.prototype.processMsg = function() {
     }
 
     if (sub.callback) {
-      // Create an ascii string out of the base64 msg before parsing to a json object
-      var msg = this.options.json ? JSON.parse(new Buffer(this.payload.msg, 'base64').toString('ascii')) : this.payload.msg;
+      var msg = this.payload.msg;
+      if (this.options.json) {
+        try {
+          msg = JSON.parse(new Buffer(this.payload.msg, this.options.encoding).toString())
+        } catch (e) {
+          msg = e;
+        }
+      }
       sub.callback(msg, this.payload.reply, this.payload.subj, this.payload.sid);
     }
   }
@@ -931,9 +932,18 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
   }
 
   // Need to treat sending buffers different.
-
   if (!Buffer.isBuffer(msg)) {
-    var str = this.options.json ? JSON.stringify(msg) : msg;
+    var str = msg;
+    if (this.options.json) {
+      if (typeof msg !== 'object' || Array.isArray(msg)) {
+        throw(BAD_JSON_MSG_ERR);
+      }
+      try {
+        str = JSON.stringify(msg)
+      } catch (e) {
+        throw(BAD_JSON_MSG_ERR);
+      }
+    }
     this.sendCommand(psub + Buffer.byteLength(str) + CR_LF + str + CR_LF);
   } else {
     var b = new Buffer(psub.length + msg.length + (2 * CR_LF_LEN) + msg.length.toString().length);

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -847,7 +847,7 @@ Client.prototype.processMsg = function() {
       var msg = this.payload.msg;
       if (this.options.json) {
         try {
-          msg = JSON.parse(new Buffer(this.payload.msg, this.options.encoding).toString())
+          msg = JSON.parse(new Buffer(this.payload.msg, this.options.encoding).toString());
         } catch (e) {
           msg = e;
         }
@@ -939,7 +939,7 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
         throw(BAD_JSON_MSG_ERR);
       }
       try {
-        str = JSON.stringify(msg)
+        str = JSON.stringify(msg);
       } catch (e) {
         throw(BAD_JSON_MSG_ERR);
       }

--- a/test/basics.js
+++ b/test/basics.js
@@ -254,17 +254,81 @@ describe('Basics', function() {
   it('should parse json messages', function(done) {
     var config = {
       port: PORT,
-      json: true
+      json: true,
     };
     var nc = NATS.connect(config);
     var jsonMsg = {
-      json: true
+      key: true
     };
-    nc.subscribe('foo', function(msg) {
-      msg.should.have.property('json').and.be.a.Boolean();
+    nc.subscribe('foo1', function(msg) {
+      msg.should.have.property('key').and.be.a.Boolean();
       done();
     });
-    nc.publish('foo', jsonMsg);
+    nc.publish('foo1', jsonMsg);
+  });
+
+  it('should parse UTF8 json messages', function(done) {
+    var config = {
+      port: PORT,
+      json: true,
+    };
+    var nc = NATS.connect(config);
+    var utf8msg = {
+      key: 'CEDILA-Ç'
+    };
+    nc.subscribe('foo2', function(msg) {
+      msg.should.have.property('key');
+      msg.key.should.equal('CEDILA-Ç')
+      done();
+    });
+    nc.publish('foo2', utf8msg);
+  });
+
+  it('should validate json messages before publishing', function(done) {
+    var config = {
+      port: PORT,
+      json: true,
+    };
+    var nc = NATS.connect(config);
+    var error;
+
+    try {
+      nc.publish('foo3', 'not JSON');
+    } catch (e) {
+      error = e;
+    }
+    if (!error) {
+      done('Should not accept string as message when JSON switch is turned on');
+    }
+
+    try {
+      nc.publish('foo3', 1);
+    } catch (e) {
+      error = e;
+    }
+    if (!error) {
+      done('Should not accept number as message when JSON switch is turned on');
+    }
+
+    try {
+      nc.publish('foo3', false);
+    } catch (e) {
+      error = e;
+    }
+    if (!error) {
+      done('Should not accept boolean as message when JSON switch is turned on');
+    }
+
+    try {
+      nc.publish('foo3', []);
+    } catch (e) {
+      error = e;
+    }
+    if (!error) {
+      done('Should not accept array as message when JSON switch is turned on');
+    }
+
+    done();
   });
 
 });

--- a/test/basics.js
+++ b/test/basics.js
@@ -278,7 +278,7 @@ describe('Basics', function() {
     };
     nc.subscribe('foo2', function(msg) {
       msg.should.have.property('key');
-      msg.key.should.equal('CEDILA-Ç')
+      msg.key.should.equal('CEDILA-Ç');
       done();
     });
     nc.publish('foo2', utf8msg);

--- a/test/basics.js
+++ b/test/basics.js
@@ -251,4 +251,20 @@ describe('Basics', function() {
     nc.publish('foo');
   });
 
+  it('should parse json messages', function(done) {
+    var config = {
+      port: PORT,
+      json: true
+    };
+    var nc = NATS.connect(config);
+    var jsonMsg = {
+      json: true
+    };
+    nc.subscribe('foo', function(msg) {
+      msg.should.have.property('json').and.be.a.Boolean();
+      done();
+    });
+    nc.publish('foo', jsonMsg);
+  });
+
 });

--- a/test/basics.js
+++ b/test/basics.js
@@ -262,6 +262,7 @@ describe('Basics', function() {
     };
     nc.subscribe('foo1', function(msg) {
       msg.should.have.property('key').and.be.a.Boolean();
+      nc.close();
       done();
     });
     nc.publish('foo1', jsonMsg);
@@ -270,7 +271,7 @@ describe('Basics', function() {
   it('should parse UTF8 json messages', function(done) {
     var config = {
       port: PORT,
-      json: true,
+      json: true
     };
     var nc = NATS.connect(config);
     var utf8msg = {
@@ -279,6 +280,7 @@ describe('Basics', function() {
     nc.subscribe('foo2', function(msg) {
       msg.should.have.property('key');
       msg.key.should.equal('CEDILA-Ç');
+      nc.close();
       done();
     });
     nc.publish('foo2', utf8msg);
@@ -287,7 +289,7 @@ describe('Basics', function() {
   it('should validate json messages before publishing', function(done) {
     var config = {
       port: PORT,
-      json: true,
+      json: true
     };
     var nc = NATS.connect(config);
     var error;
@@ -298,7 +300,8 @@ describe('Basics', function() {
       error = e;
     }
     if (!error) {
-      done('Should not accept string as message when JSON switch is turned on');
+      nc.close();
+      return done('Should not accept string as message when JSON switch is turned on');
     }
 
     try {
@@ -307,7 +310,8 @@ describe('Basics', function() {
       error = e;
     }
     if (!error) {
-      done('Should not accept number as message when JSON switch is turned on');
+      nc.close();
+      return done('Should not accept number as message when JSON switch is turned on');
     }
 
     try {
@@ -316,7 +320,8 @@ describe('Basics', function() {
       error = e;
     }
     if (!error) {
-      done('Should not accept boolean as message when JSON switch is turned on');
+      nc.close();
+      return done('Should not accept boolean as message when JSON switch is turned on');
     }
 
     try {
@@ -325,9 +330,11 @@ describe('Basics', function() {
       error = e;
     }
     if (!error) {
-      done('Should not accept array as message when JSON switch is turned on');
+      nc.close();
+      return done('Should not accept array as message when JSON switch is turned on');
     }
 
+    nc.close();
     done();
   });
 


### PR DESCRIPTION
To wrap the grunt work involved in encoding and decoding JSON messages I've added a new attribute named json to the client options.
The consequences of turning the JSON attribute to true would be:
Eencoding is set to base64
-JSON object is converted to a string before being published
-Base64 strings are encoded to JSON after being received as a message in its respective subscribers

I've also added a test to the Basic suite validating the new attribute.