### PR TITLE
Fix indentation of shuffle function

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -147,13 +147,13 @@ Client.prototype.assignOption = function(opts, prop, assign) {
 };
 
 function shuffle(array) {
-    for (var i = array.length - 1; i > 0; i--) {
-        var j = Math.floor(Math.random() * (i + 1));
-        var temp = array[i];
-        array[i] = array[j];
-        array[j] = temp;
-    }
-    return array;
+  for (var i = array.length - 1; i > 0; i--) {
+    var j = Math.floor(Math.random() * (i + 1));
+    var temp = array[i];
+    array[i] = array[j];
+    array[j] = temp;
+  }
+  return array;
 }
 
 /**


### PR DESCRIPTION
I'm learning about NATS and while perusing the node client I noticed some extra indentation in the `shuffle` function.

I just removed the extra spaces.