### PR TITLE
Update publish method in json mode

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -991,12 +991,12 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
         throw(BAD_JSON_MSG_ERR);
       }
       try {
-        str = JSON.stringify(msg);
+        msg = JSON.stringify(msg);
       } catch (e) {
         throw(BAD_JSON_MSG_ERR);
       }
     }
-    this.sendCommand(psub + Buffer.byteLength(str) + CR_LF + str + CR_LF);
+    this.sendCommand(psub + Buffer.byteLength(msg) + CR_LF + msg + CR_LF);
   } else {
     var b = new Buffer(psub.length + msg.length + (2 * CR_LF_LEN) + msg.length.toString().length);
     var len = b.write(psub + msg.length + CR_LF);


### PR DESCRIPTION
In JSON mode, publish tries to set an undefined variable `str`. Using node v6 will throw a `ReferenceError: str is not defined` when trying to execute this method.