### PR TITLE
[FIX] https://github.com/nats-io/node-nats/issues/89 

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -23,7 +23,7 @@ var net    = require('net'),
  * Constants
  */
 
-var VERSION = '0.6.6',
+var VERSION = '0.6.8',
 
     DEFAULT_PORT = 4222,
     DEFAULT_PRE  = 'nats://localhost:',
@@ -67,13 +67,13 @@ var VERSION = '0.6.6',
     PONG_RESPONSE = 'PONG' + CR_LF,
 
     // Errors
-    BAD_SUBJECT_ERR = new Error('Subject must be supplied'),
-    BAD_MSG_ERR = new Error('Message can\'t be a function'),
-    BAD_REPLY_ERR = new Error('Reply can\'t be a function'),
-    CONN_CLOSED_ERR = new Error('Connection closed'),
-    BAD_JSON_MSG_ERR = new Error('Message should be a JSON object'),
-    BAD_AUTHENTICATION_ERR = new Error('User and Token can not both be provided'),
-    
+    BAD_SUBJECT = 'Subject must be supplied',
+    BAD_MSG = 'Message can\'t be a function',
+    BAD_REPLY = 'Reply can\'t be a function',
+    CONN_CLOSED = 'Connection closed',
+    BAD_JSON_MSG = 'Message should be a JSON object',
+    BAD_AUTHENTICATION = 'User and Token can not both be provided',
+
     // Pedantic Mode support
     //Q_SUB = /^([^\.\*>\s]+|>$|\*)(\.([^\.\*>\s]+|>$|\*))*$/, // TODO: remove / never used
     //Q_SUB_NO_WC = /^([^\.\*>\s]+)(\.([^\.\*>\s]+))*$/, // TODO: remove / never used
@@ -224,7 +224,7 @@ Client.prototype.parseOptions = function(opts) {
 
   // Authentication - make sure authentication is valid.
   if (client.user && client.token) {
-    throw(BAD_AUTHENTICATION_ERR);
+    throw(new Error(BAD_AUTHENTICATION));
   }
 
   // Encoding - make sure its valid.
@@ -920,10 +920,10 @@ Client.prototype.addServer = function(uri) {
 Client.prototype.flush = function(opt_callback) {
   if (this.closed) {
     if (typeof opt_callback === 'function') {
-      opt_callback(CONN_CLOSED_ERR);
+      opt_callback(new Error(CONN_CLOSED));
       return;
     } else {
-      throw(CONN_CLOSED_ERR);
+      throw(new Error(CONN_CLOSED));
     }
   }
   if (this.pongs) {
@@ -952,14 +952,14 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
   if (!msg) { msg = EMPTY; }
   if (!subject) {
     if (opt_callback) {
-      opt_callback(BAD_SUBJECT_ERR);
+      opt_callback(new Error(BAD_SUBJECT));
     } else {
-      throw(BAD_SUBJECT_ERR);
+      throw(new Error(BAD_SUBJECT));
     }
   }
   if (typeof msg === 'function') {
     if (opt_callback || opt_reply) {
-      opt_callback(BAD_MSG_ERR);
+      opt_callback(new Error(BAD_MSG));
       return;
     }
     opt_callback = msg;
@@ -968,7 +968,7 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
   }
   if (typeof opt_reply === 'function') {
     if (opt_callback) {
-      opt_callback(BAD_REPLY_ERR);
+      opt_callback(new Error(BAD_REPLY));
       return;
     }
     opt_callback = opt_reply;
@@ -988,12 +988,12 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
     var str = msg;
     if (this.options.json) {
       if (typeof msg !== 'object' || Array.isArray(msg)) {
-        throw(BAD_JSON_MSG_ERR);
+        throw(new Error(BAD_JSON_MSG));
       }
       try {
         str = JSON.stringify(msg);
       } catch (e) {
-        throw(BAD_JSON_MSG_ERR);
+        throw(new Error(BAD_JSON_MSG));
       }
     }
     this.sendCommand(psub + Buffer.byteLength(str) + CR_LF + str + CR_LF);
@@ -1008,7 +1008,7 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
   if (opt_callback !== undefined) {
     this.flush(opt_callback);
   } else if (this.closed) {
-    throw(CONN_CLOSED_ERR);
+    throw(new Error(CONN_CLOSED));
   }
 };
 
@@ -1025,7 +1025,7 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
 
 Client.prototype.subscribe = function(subject, opts, callback) {
   if (this.closed) {
-    throw(CONN_CLOSED_ERR);
+    throw(new Error(CONN_CLOSED));
   }
   var qgroup, max;
   if (typeof opts === 'function') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "0.6.6",
+  "version": "0.6.8",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",


### PR DESCRIPTION
Stacktraces are not meaningful because Error objects are created with the library. Library now simply adds the error messages and constructs the error where thrown.