### PR TITLE
support raw buffers with {encoding: null}

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ nc2.publish('foo');
 
 nc = nats.connect({'servers':servers, 'encoding': 'ascii'});
 
+// Setting encoding to null explicitly allows messages to be sent and recieved
+// as raw Buffer objects.
+
+nc = nats.connect({'servers':servers, 'encoding': null});
+
+nats.subscribe('foo', function(response) {
+  var rawInt = response.readInt32LE(0);
+  console.log('Got a raw integer from the response buffer: ' + rawInt);
+});
+
 ```
 
 See examples and benchmarks for more information..

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -228,7 +228,7 @@ Client.prototype.parseOptions = function(opts) {
   }
 
   // Encoding - make sure its valid.
-  if (Buffer.isEncoding(options.encoding)) {
+  if (options.encoding === null || Buffer.isEncoding(options.encoding)) {
     client.encoding = options.encoding;
   } else {
     throw new Error('Invalid Encoding:' + options.encoding);
@@ -806,11 +806,19 @@ Client.prototype.processInbound = function() {
       // If we are here we have the complete message.
       // Check to see if we have existing chunks
       if (client.payload.chunks) {
-	client.payload.chunks.push(client.inbound.slice(0, client.payload.psize));
-	var mbuf = Buffer.concat(client.payload.chunks, client.payload.size+CR_LF_LEN);
-	client.payload.msg = mbuf.toString(client.encoding, 0, client.payload.size);
+        client.payload.chunks.push(client.inbound.slice(0, client.payload.psize));
+        var mbuf = Buffer.concat(client.payload.chunks, client.payload.size+CR_LF_LEN);
+        if(client.encoding !== null) {
+          client.payload.msg = mbuf.toString(client.encoding, 0, client.payload.size);
+        } else {
+          client.payload.msg = mbuf.slice(0, client.payload.size);
+        }
       } else {
-	client.payload.msg = client.inbound.toString(client.encoding, 0, client.payload.size);
+        if(client.encoding !== null) {
+          client.payload.msg = client.inbound.toString(client.encoding, 0, client.payload.size);
+        } else {
+          client.payload.msg = client.inbound.slice(0, client.payload.size);
+        }
       }
 
       // Eat the size of the inbound that represents the message.

--- a/test/raw.js
+++ b/test/raw.js
@@ -1,0 +1,61 @@
+/* jslint node: true */
+/* global describe: false, before: false, after: false, it: false */
+'use strict';
+
+
+var NATS = require ('../'),
+nsc = require('./support/nats_server_control'),
+should = require('should');
+
+describe('raw buffer payloads', function() {
+
+  var PORT = 1423;
+  var server;
+
+  // Start up our own nats-server
+  before(function (done) {
+    server = nsc.start_server(PORT, done);
+  });
+
+  // Shutdown our server
+  after(function () {
+    server.kill();
+  });
+
+
+  it('should pub/sub with raw buffers', function(done){
+    var nc = NATS.connect({encoding: null, port: PORT});
+    nc.subscribe('foo', function(msg, reply, subj, sid){
+      should.ok(Buffer.isBuffer(msg));
+      msg.toString('utf8', 0, 2).should.equal('hi');
+      msg.length.should.equal(4);
+      msg[2].should.equal(255);
+      msg[3].should.equal(0);
+      nc.unsubscribe(sid);
+      nc.close();
+      done();
+    });
+
+    var buf = new Buffer(4);
+    buf[0] = 104;
+    buf[1] = 105;
+    buf[2] = 255;
+    buf[3] = 0;
+    nc.publish('foo', buf);
+  });
+
+  it('should pub/sub raw buffers even when given strings', function(done){
+    var nc = NATS.connect({encoding: null, port: PORT});
+    nc.subscribe('foo', function(msg, reply, subj, sid){
+      should.ok(Buffer.isBuffer(msg));
+      msg.toString('utf8', 0, 5).should.equal('hello');
+      msg.length.should.equal(5);
+      nc.unsubscribe(sid);
+      nc.close();
+      done();
+    });
+
+    nc.publish('foo', 'hello');
+  });
+
+});


### PR DESCRIPTION
# Overview

Allow the use of raw Buffer objects with node-nats, by passing `{encoding: null}` as an explicit option. Note that the default encoding, UTF8, is not changed.
