### PR TITLE
Remove unused CR_LF_BUF variable

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -52,7 +52,6 @@ var VERSION = '0.6.8',
 
     CR_LF = '\r\n',
     CR_LF_LEN = CR_LF.length,
-    CR_LF_BUF = new Buffer(CR_LF),
     EMPTY = '',
     SPC = ' ',
 


### PR DESCRIPTION
CR_LF_BUF doesn't appear to be used anywhere. All tests pass after removal.