### PR TITLE
[FIX] #104 - errors emitted by the library are now errors and not strings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,3 +126,12 @@ declare class Client extends events.EventEmitter {
 	 */
 	numSubscriptions(): number;
 }
+
+declare class NatsError implements Error {
+    public name: string;
+    public message: string;
+    public code: string;
+    public chainedError: Error;
+
+    constructor(message:string, code:string, chainedError?:Error);
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,21 @@ import events = require('events');
 export const version: string;
 
 /**
+ * Error codes
+ */
+export const BAD_SUBJECT: string;
+export const BAD_MSG: string;
+export const BAD_REPLY: string;
+export const CONN_CLOSED: string;
+export const BAD_JSON: string;
+export const BAD_AUTHENTICATION: string;
+export const INVALID_ENCODING: string;
+export const SECURE_CONN_REQ: string;
+export const NON_SECURE_CONN_REQ: string;
+export const CLIENT_CERT_REQ: string;
+export const NATS_PROTOCOL_ERR: string;
+
+/**
  * Create a properly formatted inbox subject.
 */
 export function createInbox(): string;

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -86,6 +86,8 @@ var VERSION = '0.7.0',
     NON_SECURE_CONN_REQ_MSG = 'Server does not support a secure connection.',
     CLIENT_CERT_REQ = 'CLIENT_CERT_REQ',
     CLIENT_CERT_REQ_MSG = 'Server requires a client certificate.',
+    CONN_ERR = 'CONN_ERR',
+    CONN_ERR_MSG_PREFIX = 'Could not connect to server: ',
     NATS_PROTOCOL_ERR = 'NATS_PROTOCOL_ERR',
 
     // Pedantic Mode support
@@ -94,10 +96,20 @@ var VERSION = '0.7.0',
 
     FLUSH_THRESHOLD = 65536;
 
+
+  var NatsError = function(message, code, chainedError) {
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.message = message;
+    this.code = code;
+    this.chainedError = chainedError;
+  };
+  util.inherits(NatsError, Error);
+  exports.NatsError = NatsError;
+
 /**
  * Library Version
  */
-
 exports.version = VERSION;
 
 /**
@@ -254,14 +266,14 @@ Client.prototype.parseOptions = function(opts) {
 
   // Authentication - make sure authentication is valid.
   if (client.user && client.token) {
-    throw(new Error(BAD_AUTHENTICATION_MSG, BAD_AUTHENTICATION));
+    throw(new NatsError(BAD_AUTHENTICATION_MSG, BAD_AUTHENTICATION));
   }
 
   // Encoding - make sure its valid.
   if (Buffer.isEncoding(options.encoding)) {
     client.encoding = options.encoding;
   } else {
-    throw new Error(INVALID_ENCODING_MSG_PREFIX + options.encoding, INVALID_ENCODING);
+    throw new NatsError(INVALID_ENCODING_MSG_PREFIX + options.encoding, INVALID_ENCODING);
   }
   // For cluster support
   client.servers = [];
@@ -338,14 +350,14 @@ Client.prototype.selectServer = function() {
 Client.prototype.checkTLSMismatch = function() {
   if (this.info.tls_required === true &&
       this.options.tls === false) {
-    this.emit('error', new Error(SECURE_CONN_REQ_MSG, SECURE_CONN_REQ));
+    this.emit('error', new NatsError(SECURE_CONN_REQ_MSG, SECURE_CONN_REQ));
     this.closeStream();
     return true;
   }
 
   if (this.info.tls_required === false &&
       this.options.tls !== false) {
-    this.emit('error', new Error(NON_SECURE_CONN_REQ_MSG, NON_SECURE_CONN_REQ));
+    this.emit('error', new NatsError(NON_SECURE_CONN_REQ_MSG, NON_SECURE_CONN_REQ));
     this.closeStream();
     return true;
   }
@@ -432,7 +444,7 @@ Client.prototype.setupHandlers = function() {
     // Only bubble up error if we never had connected
     // to the server and we only have one.
     if (client.wasConnected === false && client.servers.length === 0) {
-      client.emit('error', exception);
+      client.emit('error', new NatsError(CONN_ERR_MSG_PREFIX + exception, CONN_ERR, exception));
     }
     client.closeStream();
   });
@@ -950,10 +962,10 @@ Client.prototype.addServer = function(uri) {
 Client.prototype.flush = function(opt_callback) {
   if (this.closed) {
     if (typeof opt_callback === 'function') {
-      opt_callback(new Error(CONN_CLOSED_MSG, CONN_CLOSED));
+      opt_callback(new NatsError(CONN_CLOSED_MSG, CONN_CLOSED));
       return;
     } else {
-      throw(new Error(CONN_CLOSED_MSG, CONN_CLOSED));
+      throw(new NatsError(CONN_CLOSED_MSG, CONN_CLOSED));
     }
   }
   if (this.pongs) {
@@ -982,14 +994,14 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
   if (!msg) { msg = EMPTY; }
   if (!subject) {
     if (opt_callback) {
-      opt_callback(new Error(BAD_SUBJECT_MSG, BAD_SUBJECT));
+      opt_callback(new NatsError(BAD_SUBJECT_MSG, BAD_SUBJECT));
     } else {
-      throw(new Error(BAD_SUBJECT_MSG, BAD_SUBJECT));
+      throw(new NatsError(BAD_SUBJECT_MSG, BAD_SUBJECT));
     }
   }
   if (typeof msg === 'function') {
     if (opt_callback || opt_reply) {
-      opt_callback(new Error(BAD_MSG_MSG, BAD_MSG));
+      opt_callback(new NatsError(BAD_MSG_MSG, BAD_MSG));
       return;
     }
     opt_callback = msg;
@@ -998,7 +1010,7 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
   }
   if (typeof opt_reply === 'function') {
     if (opt_callback) {
-      opt_callback(new Error(BAD_REPLY_MSG, BAD_REPLY));
+      opt_callback(new NatsError(BAD_REPLY_MSG, BAD_REPLY));
       return;
     }
     opt_callback = opt_reply;
@@ -1018,12 +1030,12 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
     var str = msg;
     if (this.options.json) {
       if (typeof msg !== 'object' || Array.isArray(msg)) {
-        throw(new Error(BAD_JSON_MSG, BAD_JSON));
+        throw(new NatsError(BAD_JSON_MSG, BAD_JSON));
       }
       try {
         str = JSON.stringify(msg);
       } catch (e) {
-        throw(new Error(BAD_JSON_MSG, BAD_JSON));
+        throw(new NatsError(BAD_JSON_MSG, BAD_JSON));
       }
     }
     this.sendCommand(psub + Buffer.byteLength(str) + CR_LF + str + CR_LF);
@@ -1038,7 +1050,7 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
   if (opt_callback !== undefined) {
     this.flush(opt_callback);
   } else if (this.closed) {
-    throw(new Error(CONN_CLOSED_MSG, CONN_CLOSED));
+    throw(new NatsError(CONN_CLOSED_MSG, CONN_CLOSED));
   }
 };
 
@@ -1055,7 +1067,7 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
 
 Client.prototype.subscribe = function(subject, opts, callback) {
   if (this.closed) {
-    throw(new Error(CONN_CLOSED_MSG, CONN_CLOSED));
+    throw(new NatsError(CONN_CLOSED_MSG, CONN_CLOSED));
   }
   var qgroup, max;
   if (typeof opts === 'function') {

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -23,7 +23,7 @@ var net    = require('net'),
  * Constants
  */
 
-var VERSION = '0.6.8',
+var VERSION = '0.7.0',
 
     DEFAULT_PORT = 4222,
     DEFAULT_PRE  = 'nats://localhost:',
@@ -66,12 +66,27 @@ var VERSION = '0.6.8',
     PONG_RESPONSE = 'PONG' + CR_LF,
 
     // Errors
-    BAD_SUBJECT = 'Subject must be supplied',
-    BAD_MSG = 'Message can\'t be a function',
-    BAD_REPLY = 'Reply can\'t be a function',
-    CONN_CLOSED = 'Connection closed',
+    BAD_SUBJECT = 'BAD_SUBJECT',
+    BAD_SUBJECT_MSG = 'Subject must be supplied',
+    BAD_MSG = 'BAD_MSG',
+    BAD_MSG_MSG = 'Message can\'t be a function',
+    BAD_REPLY = 'BAD_REPLY',
+    BAD_REPLY_MSG = 'Reply can\'t be a function',
+    CONN_CLOSED = 'CONN_CLOSED',
+    CONN_CLOSED_MSG = 'Connection closed',
+    BAD_JSON = 'BAD_JSON',
     BAD_JSON_MSG = 'Message should be a JSON object',
-    BAD_AUTHENTICATION = 'User and Token can not both be provided',
+    BAD_AUTHENTICATION = 'BAD_AUTHENTICATION',
+    BAD_AUTHENTICATION_MSG = 'User and Token can not both be provided',
+    INVALID_ENCODING = 'INVALID_ENCODING',
+    INVALID_ENCODING_MSG_PREFIX = 'Invalid Encoding:',
+    SECURE_CONN_REQ = 'SECURE_CONN_REQ',
+    SECURE_CONN_REQ_MSG = 'Server requires a secure connection.',
+    NON_SECURE_CONN_REQ = 'NON_SECURE_CONN_REQ',
+    NON_SECURE_CONN_REQ_MSG = 'Server does not support a secure connection.',
+    CLIENT_CERT_REQ = 'CLIENT_CERT_REQ',
+    CLIENT_CERT_REQ_MSG = 'Server requires a client certificate.',
+    NATS_PROTOCOL_ERR = 'NATS_PROTOCOL_ERR',
 
     // Pedantic Mode support
     //Q_SUB = /^([^\.\*>\s]+|>$|\*)(\.([^\.\*>\s]+|>$|\*))*$/, // TODO: remove / never used
@@ -84,6 +99,22 @@ var VERSION = '0.6.8',
  */
 
 exports.version = VERSION;
+
+/**
+ * Error codes
+ */
+exports.BAD_SUBJECT = BAD_SUBJECT;
+exports.BAD_MSG = BAD_MSG;
+exports.BAD_REPLY = BAD_REPLY;
+exports.CONN_CLOSED = CONN_CLOSED;
+exports.BAD_JSON = BAD_JSON;
+exports.BAD_AUTHENTICATION = BAD_AUTHENTICATION;
+exports.INVALID_ENCODING = INVALID_ENCODING;
+exports.SECURE_CONN_REQ = SECURE_CONN_REQ;
+exports.NON_SECURE_CONN_REQ = NON_SECURE_CONN_REQ;
+exports.CLIENT_CERT_REQ = CLIENT_CERT_REQ;
+exports.NATS_PROTOCOL_ERR = NATS_PROTOCOL_ERR;
+
 
 /**
  * Create a properly formatted inbox subject.
@@ -223,14 +254,14 @@ Client.prototype.parseOptions = function(opts) {
 
   // Authentication - make sure authentication is valid.
   if (client.user && client.token) {
-    throw(new Error(BAD_AUTHENTICATION));
+    throw(new Error(BAD_AUTHENTICATION_MSG, BAD_AUTHENTICATION));
   }
 
   // Encoding - make sure its valid.
   if (Buffer.isEncoding(options.encoding)) {
     client.encoding = options.encoding;
   } else {
-    throw new Error('Invalid Encoding:' + options.encoding);
+    throw new Error(INVALID_ENCODING_MSG_PREFIX + options.encoding, INVALID_ENCODING);
   }
   // For cluster support
   client.servers = [];
@@ -307,21 +338,21 @@ Client.prototype.selectServer = function() {
 Client.prototype.checkTLSMismatch = function() {
   if (this.info.tls_required === true &&
       this.options.tls === false) {
-    this.emit('error', 'Server requires a secure connection.');
+    this.emit('error', new Error(SECURE_CONN_REQ_MSG, SECURE_CONN_REQ));
     this.closeStream();
     return true;
   }
 
   if (this.info.tls_required === false &&
       this.options.tls !== false) {
-    this.emit('error', 'Server does not support a secure connection.');
+    this.emit('error', new Error(NON_SECURE_CONN_REQ_MSG, NON_SECURE_CONN_REQ));
     this.closeStream();
     return true;
   }
 
   if (this.info.tls_verify === true &&
       this.options.tls.cert === undefined) {
-    this.emit('error', 'Server requires a client certificate.');
+    this.emit('error', new Error(CLIENT_CERT_REQ_MSG, CLIENT_CERT_REQ));
     this.closeStream();
     return true;
   }
@@ -401,7 +432,7 @@ Client.prototype.setupHandlers = function() {
     // Only bubble up error if we never had connected
     // to the server and we only have one.
     if (client.wasConnected === false && client.servers.length === 0) {
-      client.emit('error', 'Could not connect to server: ' + exception);
+      client.emit('error', exception);
     }
     client.closeStream();
   });
@@ -737,7 +768,7 @@ Client.prototype.processInbound = function() {
       } else if ((m = OK.exec(buf)) !== null) {
         // Ignore for now..
       } else if ((m = ERR.exec(buf)) !== null) {
-        client.emit('error', m[1]);
+        client.emit('error', new Error(m[1], NATS_PROTOCOL_ERR));
       } else if ((m = PONG.exec(buf)) !== null) {
         var cb = client.pongs && client.pongs.shift();
         if (cb) { cb(); } // FIXME: Should we check for exceptions?
@@ -919,10 +950,10 @@ Client.prototype.addServer = function(uri) {
 Client.prototype.flush = function(opt_callback) {
   if (this.closed) {
     if (typeof opt_callback === 'function') {
-      opt_callback(new Error(CONN_CLOSED));
+      opt_callback(new Error(CONN_CLOSED_MSG, CONN_CLOSED));
       return;
     } else {
-      throw(new Error(CONN_CLOSED));
+      throw(new Error(CONN_CLOSED_MSG, CONN_CLOSED));
     }
   }
   if (this.pongs) {
@@ -951,14 +982,14 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
   if (!msg) { msg = EMPTY; }
   if (!subject) {
     if (opt_callback) {
-      opt_callback(new Error(BAD_SUBJECT));
+      opt_callback(new Error(BAD_SUBJECT_MSG, BAD_SUBJECT));
     } else {
-      throw(new Error(BAD_SUBJECT));
+      throw(new Error(BAD_SUBJECT_MSG, BAD_SUBJECT));
     }
   }
   if (typeof msg === 'function') {
     if (opt_callback || opt_reply) {
-      opt_callback(new Error(BAD_MSG));
+      opt_callback(new Error(BAD_MSG_MSG, BAD_MSG));
       return;
     }
     opt_callback = msg;
@@ -967,7 +998,7 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
   }
   if (typeof opt_reply === 'function') {
     if (opt_callback) {
-      opt_callback(new Error(BAD_REPLY));
+      opt_callback(new Error(BAD_REPLY_MSG, BAD_REPLY));
       return;
     }
     opt_callback = opt_reply;
@@ -987,12 +1018,12 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
     var str = msg;
     if (this.options.json) {
       if (typeof msg !== 'object' || Array.isArray(msg)) {
-        throw(new Error(BAD_JSON_MSG));
+        throw(new Error(BAD_JSON_MSG, BAD_JSON));
       }
       try {
         str = JSON.stringify(msg);
       } catch (e) {
-        throw(new Error(BAD_JSON_MSG));
+        throw(new Error(BAD_JSON_MSG, BAD_JSON));
       }
     }
     this.sendCommand(psub + Buffer.byteLength(str) + CR_LF + str + CR_LF);
@@ -1007,7 +1038,7 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
   if (opt_callback !== undefined) {
     this.flush(opt_callback);
   } else if (this.closed) {
-    throw(new Error(CONN_CLOSED));
+    throw(new Error(CONN_CLOSED_MSG, CONN_CLOSED));
   }
 };
 
@@ -1024,7 +1055,7 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
 
 Client.prototype.subscribe = function(subject, opts, callback) {
   if (this.closed) {
-    throw(new Error(CONN_CLOSED));
+    throw(new Error(CONN_CLOSED_MSG, CONN_CLOSED));
   }
   var qgroup, max;
   if (typeof opts === 'function') {

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -364,7 +364,7 @@ Client.prototype.checkTLSMismatch = function() {
 
   if (this.info.tls_verify === true &&
       this.options.tls.cert === undefined) {
-    this.emit('error', new Error(CLIENT_CERT_REQ_MSG, CLIENT_CERT_REQ));
+    this.emit('error', new NatsError(CLIENT_CERT_REQ_MSG, CLIENT_CERT_REQ));
     this.closeStream();
     return true;
   }
@@ -780,7 +780,7 @@ Client.prototype.processInbound = function() {
       } else if ((m = OK.exec(buf)) !== null) {
         // Ignore for now..
       } else if ((m = ERR.exec(buf)) !== null) {
-        client.emit('error', new Error(m[1], NATS_PROTOCOL_ERR));
+        client.emit('error', new NatsError(m[1], NATS_PROTOCOL_ERR));
       } else if ((m = PONG.exec(buf)) !== null) {
         var cb = client.pongs && client.pongs.shift();
         if (cb) { cb(); } // FIXME: Should we check for exceptions?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "0.6.8",
+  "version": "0.7.0",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",

--- a/test/errors.js
+++ b/test/errors.js
@@ -88,7 +88,7 @@ describe('Errors', function() {
     var err = new NATS.NatsError("hello", "helloid", srcErr);
     should.equal(err.message, 'hello');
     should.equal(err.code, 'helloid');
-    should.equal(err.chainedError, srcErr)
+    should.equal(err.chainedError, srcErr);
   });
 
 });

--- a/test/errors.js
+++ b/test/errors.js
@@ -77,4 +77,18 @@ describe('Errors', function() {
     done();
   });
 
+  it ('NatsErrors have code', function() {
+    var err = new NATS.NatsError("hello", "helloid");
+    should.equal(err.message, 'hello');
+    should.equal(err.code, 'helloid');
+  });
+
+  it ('NatsErrors can chain an error', function() {
+    var srcErr = new Error('foo');
+    var err = new NATS.NatsError("hello", "helloid", srcErr);
+    should.equal(err.message, 'hello');
+    should.equal(err.code, 'helloid');
+    should.equal(err.chainedError, srcErr)
+  });
+
 });


### PR DESCRIPTION
All errors thrown/emitted now have codes that can be used for testing the type of error raised. Errors emitted by the library are now errors and not strings. In the case of connection
errors, the original error raised by the OS is surfaced.

**If your client code depends on the value of the messages, you will have to update your code before upgrading to the library.** To aid in handing, the Error objects can be tested, but a more reliable way is provided by the new constants (BAD_SUBJECT, BAD_MSG, BAD_REPLY, CONN_CLOSED, BAD_JSON, BAD_AUTHENTICATION, INVALID_ENCODING, SECURE_CONN_REQ, NON_SECURE_CONN_REQ, CERT_REQ, NATS_PROTOCOL_ERR)