### PR TITLE
Fix array publishing with json

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -1049,7 +1049,7 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
   if (!Buffer.isBuffer(msg)) {
     var str = msg;
     if (this.options.json) {
-      if (typeof msg !== 'object' || Array.isArray(msg)) {
+      if (typeof msg !== 'object') {
         throw(new NatsError(BAD_JSON_MSG, BAD_JSON));
       }
       try {


### PR DESCRIPTION
When using options `{ json: true }` trying to publish an array results in `BAD_JSON` exception.

This PR just fixes inaccurate conditional. Because `typeof []` is `'object'`.