### PR TITLE
Allow `close` and `disconnect` events to fire

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -583,7 +583,9 @@ Client.prototype.initState = function() {
 
 Client.prototype.close = function() {
   this.closed = true;
-  this.removeAllListeners();
+  this.once('close', function(){
+    this.removeAllListeners();
+  });
   this.closeStream();
   this.ssid     = -1;
   this.subs     = null;


### PR DESCRIPTION
If any code is listening for the `close` or `disconnect` the  `nats.close()` method will remove the listener and the event will never fire. This prevents applications from trying to gracefully track any shutdown processes.

This also solves any potential for issues such as #33 