### PR TITLE
[FIX] #145 - when using TLS reconnects would fail because of listener leaks (events firing on leaked streams)

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -23,7 +23,7 @@ var net    = require('net'),
  * Constants
  */
 
-var VERSION = '0.7.18',
+var VERSION = '0.7.20',
 
     DEFAULT_PORT = 4222,
     DEFAULT_PRE  = 'nats://localhost:',
@@ -91,6 +91,8 @@ var VERSION = '0.7.18',
     NATS_PROTOCOL_ERR = 'NATS_PROTOCOL_ERR',
     REQ_TIMEOUT = 'REQ_TIMEOUT',
     REQ_TIMEOUT_MSG_PREFIX = 'The request timed out for subscription id: ',
+    STALE_CONNECTION_ERR = "stale connection",
+    PERMISSIONS_ERR = "permissions violation",
 
     // Pedantic Mode support
     //Q_SUB = /^([^\.\*>\s]+|>$|\*)(\.([^\.\*>\s]+|>$|\*))*$/, // TODO: remove / never used
@@ -415,7 +417,7 @@ Client.prototype.setupHandlers = function() {
   });
 
   stream.on('close', function(hadError) {
-    client.closeStream();
+      client.closeStream();
     client.emit('disconnect');
     if (client.closed === true ||
         client.options.reconnect === false ||
@@ -427,7 +429,7 @@ Client.prototype.setupHandlers = function() {
   });
 
   stream.on('error', function(exception) {
-    // If we were connected just return, close event will process
+      // If we were connected just return, close event will process
     if (client.wasConnected === true && client.currentServer.didConnect === true) {
       return;
     }
@@ -552,8 +554,14 @@ Client.prototype.createConnection = function() {
 
   // Select a server to connect to.
   this.selectServer();
-  // Create the stream.
-  this.stream = net.createConnection(this.url.port, this.url.hostname);
+    // See #45 if we have a stream release the listeners
+  // otherwise in addition to the leak events will fire fire
+  if(this.stream) {
+      this.stream.removeAllListeners();
+      this.stream.end();
+  }
+    // Create the stream
+    this.stream = net.createConnection(this.url.port, this.url.hostname);
   // Setup the proper handlers.
   this.setupHandlers();
 };
@@ -603,7 +611,7 @@ Client.prototype.closeStream = function() {
   if (this.stream !== null) {
     this.stream.end();
     this.stream.destroy();
-    this.stream  = null;
+    this.stream = null;
   }
   if (this.connected === true || this.closed === true) {
     this.pongs     = null;
@@ -756,6 +764,11 @@ Client.prototype.processInbound = function() {
   // For optional yield
   var start;
 
+  if(! client.stream) {
+      // if we are here, the stream was reaped and errors raised
+      // if we continue.
+      return;
+  }
   // unpause if needed.
   // FIXME(dlc) client.stream.isPaused() causes 0.10 to fail
   client.stream.resume();
@@ -785,7 +798,8 @@ Client.prototype.processInbound = function() {
       } else if ((m = OK.exec(buf)) !== null) {
         // Ignore for now..
       } else if ((m = ERR.exec(buf)) !== null) {
-        client.emit('error', new NatsError(m[1], NATS_PROTOCOL_ERR));
+          client.processErr(m[1]);
+          return;
       } else if ((m = PONG.exec(buf)) !== null) {
         var cb = client.pongs && client.pongs.shift();
         if (cb) { cb(); } // FIXME: Should we check for exceptions?
@@ -835,6 +849,11 @@ Client.prototype.processInbound = function() {
 		tlsOpts[key] = client.options.tls[key];
 	      }
 	    }
+	    // if we have a stream, this is from an old connection, reap it
+	    if(client.stream) {
+            client.stream.removeAllListeners();
+            client.stream.end();
+        }
 	    client.stream = tls.connect(tlsOpts, function() {
 	      client.flushPending();
 	    });
@@ -984,6 +1003,25 @@ Client.prototype.processMsg = function() {
       sub.callback(msg, this.payload.reply, this.payload.subj, this.payload.sid);
     }
   }
+};
+
+/**
+ * ProcessErr processes any error messages from the server
+ *
+ * @api private
+ */
+Client.prototype.processErr = function(s) {
+    // current NATS clients, will raise an error and close on any errors
+    // except stale connection and permission errors
+    var m = s ? s.toLowerCase() : '';
+    if(m.indexOf(STALE_CONNECTION_ERR) !== -1) {
+      this.scheduleReconnect();
+    } else if(m.indexOf(PERMISSIONS_ERR) !== -1) {
+      this.emit('permission_error', new NatsError(s, NATS_PROTOCOL_ERR));
+    } else {
+      this.emit('error', new NatsError(s, NATS_PROTOCOL_ERR));
+      this.closeStream();
+    }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "0.7.18",
+  "version": "0.7.20",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",

--- a/test/dyncluster.js
+++ b/test/dyncluster.js
@@ -3,141 +3,259 @@
 /* jshint -W030 */
 'use strict';
 
-var NATS = require ('../'),
-    nsc = require('./support/nats_server_control'),
-    should = require('should');
+var NATS = require('../'),
+nsc = require('./support/nats_server_control'),
+ncu = require('./support/nats_conf_utils'),
+should = require('should'),
+path = require('path'),
+os = require('os'),
+fs = require('fs'),
+nuid = require('nuid');
 
-describe('Dynamic Cluster - Connect URLs', function() {
-  this.timeout(10000);
+describe('Dynamic Cluster - Connect URLs', function () {
+    this.timeout(10000);
 
-  // this to enable per test cleanup
-  var servers;
-  // Shutdown our servers
-  afterEach(function() {
-    nsc.stop_cluster(servers);
-    servers = [];
-  });
+    // this to enable per test cleanup
+    var servers;
+    // Shutdown our servers
+    afterEach(function () {
+        nsc.stop_cluster(servers);
+        servers = [];
+    });
 
-  it('adding cluster performs update', function(done) {
-    var route_port = 54220;
-    var port = 54221;
+    it('adding cluster performs update', function (done) {
+        var route_port = 54220;
+        var port = 54221;
 
-    // start a new cluster with single server
-    servers = nsc.start_cluster([port], route_port, function() {
-      should(servers.length).be.equal(1);
+        // start a new cluster with single server
+        servers = nsc.start_cluster([port], route_port, function () {
+            should(servers.length).be.equal(1);
 
-      // connect the client
-      var nc = NATS.connect({'port': port, 'reconnectTimeWait': 100});
-      nc.on('connect', function () {
-        // start adding servers
-        process.nextTick(function () {
-          var others = nsc.add_member_with_delay([port + 1, port + 2], route_port, 250, function () {
-            // verify that 2 servers were added
-            should(others.length).be.equal(2);
-            others.forEach(function (o) {
-              // add them so they can be reaped
-              servers.push(o);
+            // connect the client
+            var nc = NATS.connect({'port': port, 'reconnectTimeWait': 100});
+            nc.on('connect', function () {
+                // start adding servers
+                process.nextTick(function () {
+                    var others = nsc.add_member_with_delay([port + 1, port + 2], route_port, 250, function () {
+                        // verify that 2 servers were added
+                        should(others.length).be.equal(2);
+                        others.forEach(function (o) {
+                            // add them so they can be reaped
+                            servers.push(o);
+                        });
+                        // give some time for the server to send infos
+                        setTimeout(function () {
+                            // we should know of 3 servers - the one we connected and the 2 we added
+                            should(nc.servers.length).be.equal(3);
+                            done();
+                        }, 1000);
+                    });
+                });
             });
-            // give some time for the server to send infos
-            setTimeout(function () {
-              // we should know of 3 servers - the one we connected and the 2 we added
-              should(nc.servers.length).be.equal(3);
-              done();
-            }, 1000);
-          });
         });
-      });
     });
-  });
 
-  it('added servers are shuffled at the end of the list', function(done) {
-    var route_port = 54320;
-    var port = 54321;
-    // start a cluster of one server
-    var ports = [];
-    for (var i = 0; i < 10; i++) {
-      ports.push(port + i);
+    it('added servers are shuffled at the end of the list', function (done) {
+        var route_port = 54320;
+        var port = 54321;
+        // start a cluster of one server
+        var ports = [];
+        for (var i = 0; i < 10; i++) {
+            ports.push(port + i);
+        }
+        var map = {};
+        servers = nsc.start_cluster(ports, route_port, function () {
+            should(servers.length).be.equal(10);
+
+            var connectCount = 0;
+
+            function connectAndRecordPorts(check) {
+                var nc = NATS.connect({'port': port, 'reconnectTimeWait': 100});
+                nc.on('connect', function () {
+                    var have = [];
+                    nc.servers.forEach(function (s) {
+                        have.push(s.url.port);
+                    });
+
+                    connectCount++;
+                    should.ok(have[0] == port);
+                    var key = have.join("_");
+                    map[key] = map[key] ? map[key] + 1 : 1;
+                    nc.close();
+                    if (connectCount === 10) {
+                        check();
+                    }
+                });
+            }
+
+            // we should have more than one property if there was randomization
+            function check() {
+                var keys = Object.getOwnPropertyNames(map);
+                should.ok(keys.length > 1);
+                done();
+            }
+
+            // connect several times...
+            for (var i = 0; i < 10; i++) {
+                connectAndRecordPorts(check);
+            }
+        });
+    });
+
+    it('added servers not shuffled when noRandomize is set', function (done) {
+        var route_port = 54320;
+        var port = 54321;
+        // start a cluster of one server
+        var ports = [];
+        for (var i = 0; i < 10; i++) {
+            ports.push(port + i);
+        }
+        var map = {};
+        servers = nsc.start_cluster(ports, route_port, function () {
+            should(servers.length).be.equal(10);
+
+            var connectCount = 0;
+
+            function connectAndRecordPorts(check) {
+                var nc = NATS.connect({'port': port, 'reconnectTimeWait': 100, 'noRandomize': true});
+                nc.on('connect', function () {
+                    var have = [];
+                    nc.servers.forEach(function (s) {
+                        have.push(s.url.port);
+                    });
+
+                    connectCount++;
+                    should.ok(have[0] == port);
+                    var key = have.join("_");
+                    map[key] = map[key] ? map[key] + 1 : 1;
+                    nc.close();
+                    if (connectCount === 10) {
+                        check();
+                    }
+                });
+            }
+
+            // we should have more than one property if there was randomization
+            function check() {
+                var keys = Object.getOwnPropertyNames(map);
+                should.ok(keys.length === 1);
+                should.ok(map[keys[0]] === 10);
+                done();
+            }
+
+            // connect several times...
+            for (var i = 0; i < 10; i++) {
+                connectAndRecordPorts(check);
+            }
+        });
+    });
+
+    it('error connecting raises error and closes', function (done) {
+        reconnectTest(55421, 55420, true, done);
+    });
+
+    it('error connecting raises error and closes - non tls', function (done) {
+        reconnectTest(55521, 55520, false, done);
+    });
+
+    function reconnectTest(port, route_port, use_certs, done) {
+        var config = {
+            tls: {
+                cert_file: path.resolve(process.cwd(), "./test/certs/server-cert.pem"),
+                key_file: path.resolve(process.cwd(), "./test/certs/server-key.pem"),
+                ca_file: path.resolve(process.cwd(), "./test/certs/ca.pem"),
+                verify: false,
+                timeout: 2.0
+            },
+            authorization: {
+                user: "test",
+                // password is 'test'
+                password: "$2a$10$P6A99S9.wOT3yzNcz0OY/OBatni9Jl01AMuzRUkhXei6nOadn6R4C",
+                timeout: 2.0
+            }
+        };
+
+        if (!use_certs) {
+            delete config.tls;
+        }
+
+        // write two normal configs
+        var normal = JSON.parse(JSON.stringify(config));
+        var normal_conf = path.resolve(os.tmpdir(), 'normalauth_' + nuid.next() + '.conf');
+        ncu.writeFile(normal_conf, ncu.JsonToYaml(normal));
+
+        // one that has bad timeout
+        var short = JSON.parse(JSON.stringify(normal));
+
+        if(use_certs) {
+            short.tls.timeout = 0.0001;
+        }
+        short.authorization.timeout = 0.0001;
+        var short_conf = path.resolve(os.tmpdir(), 'shortconf_' + nuid.next() + '.conf');
+        ncu.writeFile(short_conf, ncu.JsonToYaml(short));
+
+        // start a new cluster with single server
+        servers = nsc.start_cluster([port], route_port, ['-c', normal_conf], function () {
+            process.nextTick(function () {
+                var others = nsc.add_member_with_delay([port + 1], route_port, 250, ['-c', short_conf], function () {
+                    // add the second server
+                    servers.push(others[0]);
+                    process.nextTick(function () {
+                        startClient();
+                    });
+                });
+            });
+        });
+
+        function startClient() {
+            // connect the client
+            var opts = {
+                port: port,
+                reconnectTimeWait: 100,
+                maxReconnectAttempts: 2,
+                user: 'test',
+                password: 'test',
+                noRandomize: true,
+                tls: {
+                    rejectUnauthorized: false
+                }
+            };
+            if(! use_certs) {
+                delete opts.tls;
+            }
+
+            var nc = NATS.connect(opts);
+            var connected = false;
+            nc.on('connect', function (c) {
+                if (!connected) {
+                    // should(nc.servers.length).be.equal(2);
+                    // now we disconnect first server
+                    connected = true;
+                    process.nextTick(function () {
+                        servers[0].kill();
+                    });
+                }
+            });
+
+            var errors = [];
+            nc.on('error', function (e) {
+                // save the error
+                errors.push(e);
+            });
+            nc.on('close', function () {
+                should.ok(connected);
+                // for tls the error isn't always raised so we'll just trust
+                // that we we tried connecting to the bad server
+                should.ok(errors.length === 1 || disconnects.indexOf((port+1)+'') !== -1);
+                done();
+            });
+            var disconnects = [];
+            nc.on('disconnect', function() {
+                var p = nc.currentServer.url.port;
+                if(disconnects.indexOf(p) === -1) {
+                    disconnects.push(p);
+                }
+            });
+        }
     }
-    var map = {};
-    servers = nsc.start_cluster(ports, route_port, function () {
-      should(servers.length).be.equal(10);
-
-      var connectCount = 0;
-      function connectAndRecordPorts(check) {
-        var nc = NATS.connect({'port': port, 'reconnectTimeWait': 100});
-        nc.on('connect', function () {
-          var have = [];
-          nc.servers.forEach(function (s) {
-            have.push(s.url.port);
-          });
-
-          connectCount++;
-          should.ok(have[0] == port);
-          var key = have.join("_");
-          map[key] = map[key] ? map[key] + 1 : 1;
-          nc.close();
-          if (connectCount === 10) {
-            check();
-          }
-        });
-      }
-
-      // we should have more than one property if there was randomization
-      function check() {
-        var keys = Object.getOwnPropertyNames(map);
-        should.ok(keys.length > 1);
-        done();
-      }
-      // connect several times...
-      for (var i = 0; i < 10; i++) {
-        connectAndRecordPorts(check);
-      }
-    });
-  });
-
-  it('added servers not shuffled when noRandomize is set', function(done) {
-    var route_port = 54320;
-    var port = 54321;
-    // start a cluster of one server
-    var ports = [];
-    for (var i = 0; i < 10; i++) {
-      ports.push(port + i);
-    }
-    var map = {};
-    servers = nsc.start_cluster(ports, route_port, function () {
-      should(servers.length).be.equal(10);
-
-      var connectCount = 0;
-      function connectAndRecordPorts(check) {
-        var nc = NATS.connect({'port': port, 'reconnectTimeWait': 100, 'noRandomize': true});
-        nc.on('connect', function () {
-          var have = [];
-          nc.servers.forEach(function (s) {
-            have.push(s.url.port);
-          });
-
-          connectCount++;
-          should.ok(have[0] == port);
-          var key = have.join("_");
-          map[key] = map[key] ? map[key] + 1 : 1;
-          nc.close();
-          if (connectCount === 10) {
-            check();
-          }
-        });
-      }
-
-      // we should have more than one property if there was randomization
-      function check() {
-        var keys = Object.getOwnPropertyNames(map);
-        should.ok(keys.length === 1);
-        should.ok(map[keys[0]] === 10);
-        done();
-      }
-      // connect several times...
-      for (var i = 0; i < 10; i++) {
-        connectAndRecordPorts(check);
-      }
-    });
-  });
 });

--- a/test/jsonyaml.js
+++ b/test/jsonyaml.js
@@ -1,0 +1,73 @@
+/* jslint node: true */
+/* global describe: false, before: false, after: false, it: false, afterEach: false, beforeEach: false */
+/* jshint -W030 */
+'use strict';
+
+var u = require('./support/nats_conf_utils'),
+    should = require('should');
+
+
+describe('NATS Conf Utils', function() {
+    it('test serializing simple', function() {
+        var x = {test: 'one'};
+        var y = u.JsonToYaml(x);
+
+        var buf = y.split('\n');
+        buf.forEach(function(e, i) {
+            buf[i] = e.trim();
+        });
+
+        var z = buf.join(' ');
+        should(z).be.equal("test: one");
+    });
+
+    it('test serializing nested', function() {
+        var x = {a: 'one', b: {a: 'two'}};
+        var y = u.JsonToYaml(x);
+
+        var buf = y.split('\n');
+        buf.forEach(function(e, i) {
+            buf[i] = e.trim();
+        });
+
+        var z = buf.join(' ');
+        should(z).be.equal("a: one b { a: two }");
+    });
+
+    it('test serializing array', function() {
+        var x = {a: 'one', b: ['a', 'b', 'c']};
+        var y = u.JsonToYaml(x);
+
+        var buf = y.split('\n');
+        buf.forEach(function(e, i) {
+            buf[i] = e.trim();
+        });
+
+        var z = buf.join(' ');
+        should(z).be.equal("a: one b [ a b c ]");
+    });
+
+    it('test serializing array objs', function() {
+        var x = {a: 'one', b: [{a: 'a'}, {b: 'b'}, {c: 'c'}]};
+        var y = u.JsonToYaml(x);
+        var buf = y.split('\n');
+        buf.forEach(function(e, i) {
+            buf[i] = e.trim();
+        });
+
+        var z = buf.join(' ');
+        should(z).be.equal("a: one b [ { a: a } { b: b } { c: c } ]");
+    });
+
+    it('test serializing array arrays', function() {
+        var x = {a: 'one', b: [{a: 'a', b: ['b', 'c']}, {b: 'b'}, {c: 'c'}]};
+        var y = u.JsonToYaml(x);
+        var buf = y.split('\n');
+        buf.forEach(function(e, i) {
+            buf[i] = e.trim();
+        });
+
+        var z = buf.join(' ');
+        should(z).be.equal("a: one b [ { a: a b [ b c ] } { b: b } { c: c } ]");
+    });
+});

--- a/test/perms.js
+++ b/test/perms.js
@@ -1,0 +1,78 @@
+/* jslint node: true */
+/* global describe: false, before: false, after: false, it: false, afterEach: false, beforeEach: false */
+/* jshint -W030 */
+'use strict';
+
+var NATS = require ('../'),
+nsc = require('./support/nats_server_control'),
+ncu = require('./support/nats_conf_utils'),
+os = require('os'),
+fs = require('fs'),
+path = require('path'),
+should = require('should'),
+nuid = require('nuid');
+
+
+describe('Auth Basics', function() {
+
+    var PORT = 6758;
+    var server;
+
+    // Start up our own nats-server
+    before(function (done) {
+        var conf = {
+            authorization: {
+                ADMIN: {
+                    publish: ">",
+                    subscribe: ">"
+                },
+                SUB: {
+                    subscribe: "bar",
+                    publish: "bar",
+                },
+                PUB: {
+                    subscribe: "foo",
+                    publish: "foo"
+                },
+                users: [
+                    {user: 'admin', password: 'admin', permission: '$ADMIN'},
+                    {user: 'foo', password: 'foo', permission: '$PUB'},
+                    {user: 'bar', password: 'bar', permission: '$SUB'}
+                ]
+            }
+        };
+        var cf = path.resolve(os.tmpdir(), 'conf-' + nuid.next() +'.conf');
+        ncu.writeFile(cf, ncu.JsonToYaml(conf));
+        server = nsc.start_server(PORT, ['-c', cf], done);
+    });
+
+    // Shutdown our server
+    after(function () {
+        nsc.stop_server(server);
+    });
+
+    it('bar cannot subscribe/pub foo', function (done) {
+        var nc = NATS.connect({
+            port: PORT,
+            user: 'bar',
+            password: 'bar'
+        });
+
+        var perms = 0;
+        nc.on('permission_error', function() {
+            perms++;
+            if(perms === 2) {
+                nc.close();
+                done();
+            }
+        });
+
+        nc.on('connect', function() {
+            nc.subscribe('foo', function() {
+                nc.close();
+                done(new Error("shouldn't have been able to subscribe to foo"));
+            });
+            nc.publish('foo', '');
+        });
+    });
+});

--- a/test/support/nats_conf_utils.js
+++ b/test/support/nats_conf_utils.js
@@ -1,0 +1,39 @@
+/* jslint node: true */
+'use strict';
+
+var fs = require('fs');
+
+// TODO: add array support
+function JsonToYaml(o) {
+    var indent = arguments[1] !== undefined ? arguments[1] + '  ' : '';
+    var buf = [];
+    for (var k in o) {
+        if(o.hasOwnProperty(k)) {
+            var v = o[k];
+            if(Array.isArray(v)) {
+                buf.push(indent + k + ' [');
+                buf.push(JsonToYaml(v, indent));
+                buf.push(indent + ' ]');
+            } else if(typeof v === 'object') {
+                // don't print a key if it is an array and it is an index
+                var kn = Array.isArray(o) ? '' : k;
+                buf.push(indent + kn + ' {');
+                buf.push(JsonToYaml(v,indent));
+                buf.push(indent + ' }');
+            } else {
+                if(! Array.isArray(o)) {
+                    buf.push(indent + k + ': ' + v);
+                } else {
+                    buf.push(indent + v);
+                }
+            }
+        }
+    }
+    return buf.join('\n');
+}
+
+exports.JsonToYaml = JsonToYaml;
+
+exports.writeFile = function(fn, data) {
+    fs.writeFileSync(fn, data);
+};

--- a/test/support/nats_server_control.js
+++ b/test/support/nats_server_control.js
@@ -21,6 +21,10 @@ function start_server(port, opt_flags, done) {
     flags = flags.concat(opt_flags);
   }
 
+  if(process.env.PRINT_LAUNCH_CMD) {
+      console.log(flags.join(" "));
+  }
+
   var server = spawn(SERVER, flags);
 
   var start   = new Date();
@@ -115,7 +119,7 @@ function start_cluster(ports, route_port, opt_flags, done) {
   }
   var servers = [];
   var started = 0;
-  var server = add_member(ports[0], route_port, route_port, function() {
+  var server = add_member(ports[0], route_port, route_port, opt_flags, function() {
     started++;
     servers.push(server);
     if(started === ports.length) {
@@ -168,6 +172,7 @@ function add_member(port, route_port, cluster_port, opt_flags, done) {
   var opts = JSON.parse(JSON.stringify(opt_flags));
   opts.push('--routes', 'nats://localhost:' + route_port);
   opts.push('--cluster', 'nats://localhost:' + cluster_port);
+
   return start_server(port, opts, done);
 }
 


### PR DESCRIPTION
[FIX] node client fired error on any protocol error. Some protocol errors such as 'stale connection' should have initiated a reconnect.
[FIX] if a client attempted to publish/subscribe to a subject for which it had no permission, an error was generated. New event ('permission_error') will now be sent to the client.

@blazedd effectively submitted a [similar PR](https://github.com/nats-io/node-nats/pull/146).