### PR TITLE
NodeJS types changed TlsOptions to TlsServerOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,7 +61,7 @@ export interface ClientOpts {
 	servers?: Array<string>,
 	noRandomize?: boolean,
 	encoding?: BufferEncoding,
-	tls?: boolean | tls.TlsOptions,
+	tls?: boolean | tls.TlsServerOptions,
 	name?: string,
 	yieldTime?: number,
 	waitOnFirstConnect?: boolean,


### PR DESCRIPTION
Updated for refactored NodeJS typings

Source: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23393/commits/e00c71172a6d67a538b27e7cfcdd1370fabdf959

This broke literally 2 days ago :( I have other TypeScript packages (like pg) that already updated to tls.TlsServerOptions so I couldn't get away with pinning @types/node-js.

Kind of a nasty gotcha because other people might have older dependencies and can't upgrade. In a perfect world we could all be up to date all the time.

If you do have the option to pin: "@types/node": "9.4.4"