### PR TITLE
New request reply

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -1443,12 +1443,19 @@ Client.prototype.initMuxRequestDetails = function(callback) {
 Client.prototype.cancelMuxRequest = function(token) {
 
     // if the token is a number, we have a fake sid, find the request
-    if(typeof token === 'number') {
-        var entry = Object.values(this.respmux.requestMap).find(function(v) {
-            return (v.id === token);
-        });
+    if (typeof token === 'number') {
+        var entry = null;
+        for (var p in this.respmux.requestMap) {
+            if (this.respmux.requestMap.hasOwnProperty(p)) {
+                var v = this.respmux.requestMap[p];
+                if (v.id === token) {
+                    entry = v;
+                    break;
+                }
+            }
+        }
 
-        if(entry) {
+        if (entry) {
             token = entry.token;
         }
     }

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -210,16 +210,17 @@ function shuffle(array) {
  */
 Client.prototype.parseOptions = function(opts) {
     var options = this.options = {
-        'verbose': false,
-        'pedantic': false,
-        'reconnect': true,
-        'maxReconnectAttempts': DEFAULT_MAX_RECONNECT_ATTEMPTS,
-        'reconnectTimeWait': DEFAULT_RECONNECT_TIME_WAIT,
-        'encoding': 'utf8',
-        'tls': false,
-        'waitOnFirstConnect': false,
-        'pingInterval': DEFAULT_PING_INTERVAL,
-        'maxPingOut': DEFAULT_MAX_PING_OUT,
+        verbose: false,
+        pedantic: false,
+        reconnect: true,
+        maxReconnectAttempts: DEFAULT_MAX_RECONNECT_ATTEMPTS,
+        reconnectTimeWait: DEFAULT_RECONNECT_TIME_WAIT,
+        encoding: 'utf8',
+        tls: false,
+        waitOnFirstConnect: false,
+        pingInterval: DEFAULT_PING_INTERVAL,
+        maxPingOut: DEFAULT_MAX_PING_OUT,
+        useOldRequestStyle: false
     };
 
     if (undefined === opts) {
@@ -260,6 +261,7 @@ Client.prototype.parseOptions = function(opts) {
         this.assignOption(opts, 'preserveBuffers');
         this.assignOption(opts, 'pingInterval');
         this.assignOption(opts, 'maxPingOut');
+        this.assignOption(opts, 'useOldRequestStyle');
     }
 
     var client = this;
@@ -514,7 +516,7 @@ Client.prototype.sendConnect = function() {
         'version': VERSION,
         'verbose': this.options.verbose,
         'pedantic': this.options.pedantic,
-        'protocol': 1,
+        'protocol': 1
     };
     if (this.user !== undefined) {
         cs.user = this.user;
@@ -1237,6 +1239,14 @@ Client.prototype.unsubscribe = function(sid, opt_max) {
         return;
     }
 
+    // in the case of new muxRequest, it is possible they want perform
+    // an unsubscribe with the returned 'sid'. Intercept that and clear
+    // the request configuration. Mux requests are always negative numbers
+    if(sid < 0) {
+        this.cancelMuxRequest(sid);
+        return;
+    }
+
     var proto;
     if (opt_max) {
         proto = [UNSUB, sid, opt_max + CR_LF];
@@ -1334,12 +1344,142 @@ Client.prototype.request = function(subject, opt_msg, opt_options, callback) {
  * @param {String} opt_msg
  * @param {Object} opt_options
  * @param {Function} callback - can be called with message or NatsError if the request timed out.
- * @return {Mixed}
+ * @return {Number}
  * @api public
  */
 Client.prototype.requestOne = function(subject, opt_msg, opt_options, timeout, callback) {
+    if(this.options.useOldRequestStyle) {
+        return this.oldRequestOne(subject, opt_msg, opt_options, timeout, callback);
+    }
+
+    if (typeof opt_msg === 'number') {
+        timeout = opt_msg;
+        callback = opt_options;
+        opt_msg = EMPTY;
+        opt_options = null;
+    }
+
+    if (typeof opt_options === 'number') {
+        timeout = opt_options;
+        callback = timeout;
+        opt_options = null;
+    }
+
     opt_options = opt_options || {};
     opt_options.max = 1;
+
+    var conf = this.initMuxRequestDetails(callback);
+    this.publish(subject, opt_msg, conf.inbox);
+
+    var client = this;
+    conf.timer = setTimeout(function() {
+        if(conf.callback) {
+            conf.callback(new NatsError(REQ_TIMEOUT_MSG_PREFIX + subject, REQ_TIMEOUT));
+        }
+        client.cancelMuxRequest(conf.token);
+    }, timeout);
+
+    return conf.id;
+};
+
+/**
+ * Strips the prefix of the request reply to derive the token.
+ * This is internal and only used by the new requestOne.
+ *
+ * @api private
+ */
+Client.prototype.extractToken = function(subject) {
+    return subject.substr(this.respmux.inboxPrefixLen);
+};
+
+/**
+ * Creates a subscription for the global inbox in the new requestOne.
+ * Request tokens, timer, and callbacks are tracked here.
+ *
+ * @api private
+ */
+Client.prototype.createResponseMux = function() {
+    if(!this.respmux) {
+        var client = this;
+        var inbox = createInbox();
+        var ginbox = inbox + ".*";
+        var sid = this.subscribe(ginbox, function(msg, reply, subject) {
+            var respToken = client.extractToken(subject);
+            var conf = client.cancelMuxRequest(respToken);
+            if(conf) {
+                conf.callback(msg);
+            }
+        });
+        this.respmux = {};
+        this.respmux.inbox = inbox;
+        this.respmux.inboxPrefixLen = inbox.length + 1;
+        this.respmux.subscriptionID = sid;
+        this.respmux.requestMap = {};
+        this.respmux.nextID = -1;
+    }
+    return this.respmux.inbox;
+};
+
+/**
+ * Stores the request callback and other details
+ *
+ * @api private
+ */
+Client.prototype.initMuxRequestDetails = function(callback) {
+    var ginbox = this.createResponseMux();
+    var token = nuid.next();
+    var inbox = ginbox + '.' + token;
+
+    var conf = {token: token, callback: callback, inbox: inbox, id: this.respmux.nextID--};
+    this.respmux.requestMap[token] = conf;
+    return conf;
+};
+
+/**
+ * Cancels the mux request
+ *
+ * @api private
+ */
+Client.prototype.cancelMuxRequest = function(token) {
+
+    // if the token is a number, we have a fake sid, find the request
+    if(typeof token === 'number') {
+        var entry = Object.values(this.respmux.requestMap).find(function(v) {
+            return (v.id === token);
+        });
+
+        if(entry) {
+            token = entry.token;
+        }
+    }
+
+    var conf = this.respmux.requestMap[token];
+    if (conf) {
+        if(conf.timer) {
+            clearTimeout(conf.timer);
+        }
+        delete this.respmux.requestMap[token];
+    }
+    return conf;
+};
+
+Client.prototype.oldRequestOne = function(subject, opt_msg, opt_options, timeout, callback) {
+    if (typeof opt_msg === 'number') {
+        timeout = opt_msg;
+        callback = opt_options;
+        opt_msg = EMPTY;
+        opt_options = null;
+    }
+
+    if (typeof opt_options === 'number') {
+        timeout = opt_options;
+        callback = timeout;
+        opt_options = null;
+    }
+
+    opt_options = opt_options || {};
+    opt_options.max = 1;
+
     var sid = this.request(subject, opt_msg, opt_options, callback);
     this.timeout(sid, timeout, 1, function() {
         callback(new NatsError(REQ_TIMEOUT_MSG_PREFIX + sid, REQ_TIMEOUT));

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -148,7 +148,7 @@ var createInbox = exports.createInbox = function() {
 /**
  * Initialize a client with the appropriate options.
  *
- * @param {Mixed} opts
+ * @param {Mixed} [opts]
  * @api public
  */
 function Client(opts) {
@@ -163,7 +163,7 @@ function Client(opts) {
  * Argument can be a url, or an object with a 'url'
  * property and additional options.
  *
- * @params {Mixed} opts
+ * @params {Mixed} [opts]
  *
  * @api public
  */
@@ -205,7 +205,7 @@ function shuffle(array) {
 /**
  * Parse the conctructor/connect options.
  *
- * @param {Mixed} opts
+ * @param {Mixed} [opts]
  * @api private
  */
 Client.prototype.parseOptions = function(opts) {
@@ -1079,7 +1079,7 @@ Client.prototype.addServer = function(uri) {
  * Flush outbound queue to server and call optional callback when server has processed
  * all data.
  *
- * @param {Function} opt_callback
+ * @param {Function} [opt_callback]
  * @api public
  */
 Client.prototype.flush = function(opt_callback) {
@@ -1102,9 +1102,9 @@ Client.prototype.flush = function(opt_callback) {
  * Publish a message to the given subject, with optional reply and callback.
  *
  * @param {String} subject
- * @param {String} opt_msg
- * @param {String} opt_reply
- * @param {Function} opt_callback
+ * @param {String} [opt_msg]
+ * @param {String} [opt_reply]
+ * @param {Function} [opt_callback]
  * @api public
  */
 Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
@@ -1183,7 +1183,7 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
  * ommitted, even with a callback. The Subscriber Id is returned.
  *
  * @param {String} subject
- * @param {Object} opts
+ * @param {Object} [opts]
  * @param {Function} callback
  * @return {Mixed}
  * @api public
@@ -1231,7 +1231,7 @@ Client.prototype.subscribe = function(subject, opts, callback) {
  * will clear any pending timeout callbacks.
  *
  * @param {Mixed} sid
- * @param {Number} opt_max
+ * @param {Number} [opt_max]
  * @api public
  */
 Client.prototype.unsubscribe = function(sid, opt_max) {
@@ -1305,8 +1305,8 @@ Client.prototype.timeout = function(sid, timeout, expected, callback) {
  * The Subscriber Id is returned.
  *
  * @param {String} subject
- * @param {String} opt_msg
- * @param {Object} opt_options
+ * @param {String} [opt_msg]
+ * @param {Object} [opt_options]
  * @param {Function} callback
  * @return {Mixed}
  * @api public
@@ -1341,8 +1341,9 @@ Client.prototype.request = function(subject, opt_msg, opt_options, callback) {
  * The Subscriber Id is returned.
  *
  * @param {String} subject
- * @param {String} opt_msg
- * @param {Object} opt_options
+ * @param {String} [opt_msg]
+ * @param {Object} [opt_options]
+ * @param {Number} timeout
  * @param {Function} callback - can be called with message or NatsError if the request timed out.
  * @return {Number}
  * @api public
@@ -1470,6 +1471,9 @@ Client.prototype.cancelMuxRequest = function(token) {
     return conf;
 };
 
+/**
+ * @api private
+ */
 Client.prototype.oldRequestOne = function(subject, opt_msg, opt_options, timeout, callback) {
     if (typeof opt_msg === 'number') {
         timeout = opt_msg;

--- a/test/basics.js
+++ b/test/basics.js
@@ -12,48 +12,48 @@ describe('Basics', function() {
     var server;
 
     // Start up our own nats-server
-    before(function(done) {
+    before(function (done) {
         server = nsc.start_server(PORT, done);
     });
 
     // Shutdown our server
-    after(function(done) {
+    after(function (done) {
         nsc.stop_server(server, done);
     });
 
-    it('should do basic subscribe and unsubscribe', function(done) {
+    it('should do basic subscribe and unsubscribe', function (done) {
         var nc = NATS.connect(PORT);
         var sid = nc.subscribe('foo');
         should.exist(sid);
         nc.unsubscribe(sid);
-        nc.flush(function() {
+        nc.flush(function () {
             nc.close();
             done();
         });
     });
 
-    it('should do basic publish', function(done) {
+    it('should do basic publish', function (done) {
         var nc = NATS.connect(PORT);
         nc.publish('foo');
-        nc.flush(function() {
+        nc.flush(function () {
             nc.close();
             done();
         });
     });
 
-    it('should fire a callback for subscription', function(done) {
+    it('should fire a callback for subscription', function (done) {
         var nc = NATS.connect(PORT);
-        nc.subscribe('foo', function() {
+        nc.subscribe('foo', function () {
             nc.close();
             done();
         });
         nc.publish('foo');
     });
 
-    it('should include the correct message in the callback', function(done) {
+    it('should include the correct message in the callback', function (done) {
         var nc = NATS.connect(PORT);
         var data = 'Hello World';
-        nc.subscribe('foo', function(msg) {
+        nc.subscribe('foo', function (msg) {
             should.exist(msg);
             msg.should.equal(data);
             nc.close();
@@ -62,11 +62,11 @@ describe('Basics', function() {
         nc.publish('foo', data);
     });
 
-    it('should include the correct reply in the callback', function(done) {
+    it('should include the correct reply in the callback', function (done) {
         var nc = NATS.connect(PORT);
         var data = 'Hello World';
         var inbox = nc.createInbox();
-        nc.subscribe('foo', function(msg, reply) {
+        nc.subscribe('foo', function (msg, reply) {
             should.exist(msg);
             msg.should.equal(data);
             should.exist(reply);
@@ -77,12 +77,12 @@ describe('Basics', function() {
         nc.publish('foo', data, inbox);
     });
 
-    it('should do request-reply', function(done) {
+    it('should do request-reply', function (done) {
         var nc = NATS.connect(PORT);
         var initMsg = 'Hello World';
         var replyMsg = 'Hello Back!';
 
-        nc.subscribe('foo', function(msg, reply) {
+        nc.subscribe('foo', function (msg, reply) {
             should.exist(msg);
             msg.should.equal(initMsg);
             should.exist(reply);
@@ -90,7 +90,7 @@ describe('Basics', function() {
             nc.publish(reply, replyMsg);
         });
 
-        nc.request('foo', initMsg, function(reply) {
+        nc.request('foo', initMsg, function (reply) {
             should.exist(reply);
             reply.should.equal(replyMsg);
             nc.close();
@@ -98,7 +98,7 @@ describe('Basics', function() {
         });
     });
 
-    it('should return a sub id for requests', function(done) {
+    it('should return a sub id for requests', function (done) {
         var nc = NATS.connect(PORT);
         var initMsg = 'Hello World';
         var replyMsg = 'Hello Back!';
@@ -106,16 +106,16 @@ describe('Basics', function() {
         var received = 0;
 
         // Add two subscribers. We will only receive a reply from one.
-        nc.subscribe('foo', function(msg, reply) {
+        nc.subscribe('foo', function (msg, reply) {
             nc.publish(reply, replyMsg);
         });
 
-        nc.subscribe('foo', function(msg, reply) {
+        nc.subscribe('foo', function (msg, reply) {
             nc.publish(reply, replyMsg);
         });
 
-        var sub = nc.request('foo', initMsg, function(reply) {
-            nc.flush(function() {
+        var sub = nc.request('foo', initMsg, function (reply) {
+            nc.flush(function () {
                 received.should.equal(expected);
                 nc.close();
                 done();
@@ -126,11 +126,11 @@ describe('Basics', function() {
         });
     });
 
-    it('should do single partial wildcard subscriptions correctly', function(done) {
+    it('should do single partial wildcard subscriptions correctly', function (done) {
         var nc = NATS.connect(PORT);
         var expected = 3;
         var received = 0;
-        nc.subscribe('*', function() {
+        nc.subscribe('*', function () {
             received += 1;
             if (received === expected) {
                 nc.close();
@@ -145,11 +145,11 @@ describe('Basics', function() {
         nc.publish('baz');
     });
 
-    it('should do partial wildcard subscriptions correctly', function(done) {
+    it('should do partial wildcard subscriptions correctly', function (done) {
         var nc = NATS.connect(PORT);
         var expected = 3;
         var received = 0;
-        nc.subscribe('foo.bar.*', function() {
+        nc.subscribe('foo.bar.*', function () {
             received += 1;
             if (received === expected) {
                 nc.close();
@@ -164,11 +164,11 @@ describe('Basics', function() {
         nc.publish('foo.bar.3');
     });
 
-    it('should do full wildcard subscriptions correctly', function(done) {
+    it('should do full wildcard subscriptions correctly', function (done) {
         var nc = NATS.connect(PORT);
         var expected = 5;
         var received = 0;
-        nc.subscribe('foo.>', function() {
+        nc.subscribe('foo.>', function () {
             received += 1;
             if (received === expected) {
                 nc.close();
@@ -183,10 +183,10 @@ describe('Basics', function() {
         nc.publish('foo.bar.3');
     });
 
-    it('should pass exact subject to callback', function(done) {
+    it('should pass exact subject to callback', function (done) {
         var nc = NATS.connect(PORT);
         var subject = 'foo.bar.baz';
-        nc.subscribe('*.*.*', function(msg, reply, subj) {
+        nc.subscribe('*.*.*', function (msg, reply, subj) {
             should.exist(subj);
             subj.should.equal(subject);
             nc.close();
@@ -195,23 +195,23 @@ describe('Basics', function() {
         nc.publish(subject);
     });
 
-    it('should do callback after publish is flushed', function(done) {
+    it('should do callback after publish is flushed', function (done) {
         var nc = NATS.connect(PORT);
-        nc.publish('foo', function() {
+        nc.publish('foo', function () {
             nc.close();
             done();
         });
     });
 
-    it('should do callback after flush', function(done) {
+    it('should do callback after flush', function (done) {
         var nc = NATS.connect(PORT);
-        nc.flush(function() {
+        nc.flush(function () {
             nc.close();
             done();
         });
     });
 
-    it('should handle an unsubscribe after close of connection', function(done) {
+    it('should handle an unsubscribe after close of connection', function (done) {
         var nc = NATS.connect(PORT);
         var sid = nc.subscribe('foo');
         nc.close();
@@ -219,28 +219,28 @@ describe('Basics', function() {
         done();
     });
 
-    it('should not receive data after unsubscribe call', function(done) {
+    it('should not receive data after unsubscribe call', function (done) {
         var nc = NATS.connect(PORT);
         var received = 0;
         var expected = 1;
 
-        var sid = nc.subscribe('foo', function() {
+        var sid = nc.subscribe('foo', function () {
             nc.unsubscribe(sid);
             received += 1;
         });
 
         nc.publish('foo');
         nc.publish('foo');
-        nc.publish('foo', function() {
+        nc.publish('foo', function () {
             received.should.equal(expected);
             nc.close();
             done();
         });
     });
 
-    it('should pass sid properly to a message callback if requested', function(done) {
+    it('should pass sid properly to a message callback if requested', function (done) {
         var nc = NATS.connect(PORT);
-        var sid = nc.subscribe('foo', function(msg, reply, subj, lsid) {
+        var sid = nc.subscribe('foo', function (msg, reply, subj, lsid) {
             sid.should.equal(lsid);
             nc.close();
             done();
@@ -248,16 +248,16 @@ describe('Basics', function() {
         nc.publish('foo');
     });
 
-    it('should parse json messages', function(done) {
+    it('should parse json messages', function (done) {
         var config = {
             port: PORT,
-            json: true,
+            json: true
         };
         var nc = NATS.connect(config);
         var jsonMsg = {
             key: true
         };
-        nc.subscribe('foo1', function(msg) {
+        nc.subscribe('foo1', function (msg) {
             msg.should.have.property('key').and.be.a.Boolean();
             nc.close();
             done();
@@ -265,7 +265,7 @@ describe('Basics', function() {
         nc.publish('foo1', jsonMsg);
     });
 
-    it('should parse UTF8 json messages', function(done) {
+    it('should parse UTF8 json messages', function (done) {
         var config = {
             port: PORT,
             json: true
@@ -274,7 +274,7 @@ describe('Basics', function() {
         var utf8msg = {
             key: 'CEDILA-Ç'
         };
-        nc.subscribe('foo2', function(msg) {
+        nc.subscribe('foo2', function (msg) {
             msg.should.have.property('key');
             msg.key.should.equal('CEDILA-Ç');
             nc.close();
@@ -283,7 +283,7 @@ describe('Basics', function() {
         nc.publish('foo2', utf8msg);
     });
 
-    it('should validate json messages before publishing', function(done) {
+    it('should validate json messages before publishing', function (done) {
         var config = {
             port: PORT,
             json: true
@@ -335,12 +335,11 @@ describe('Basics', function() {
         done();
     });
 
-    it('should do requestone-get-reply', function(done) {
-        var nc = NATS.connect(PORT);
+    function requestOneGetsReply(nc, done) {
         var initMsg = 'Hello World';
         var replyMsg = 'Hello Back!';
 
-        nc.subscribe('foo', function(msg, reply) {
+        nc.subscribe('foo', function (msg, reply) {
             should.exist(msg);
             msg.should.equal(initMsg);
             should.exist(reply);
@@ -349,7 +348,7 @@ describe('Basics', function() {
         });
 
         var gotOne = false;
-        nc.requestOne('foo', initMsg, null, 1000, function(reply) {
+        nc.requestOne('foo', initMsg, null, 1000, function (reply) {
             should.exist(reply);
             reply.should.equal(replyMsg);
             if (!gotOne) {
@@ -358,63 +357,88 @@ describe('Basics', function() {
                 done();
             }
         });
+    }
+
+    it('should do requestone-get-reply', function (done) {
+        var nc = NATS.connect(PORT);
+        requestOneGetsReply(nc, done);
     });
 
-    it('should do requestone-will-unsubscribe', function(done) {
-        // eslint-disable-next-line
-        this.timeout(3000);
+    it('oldRequestOne should do requestone-get-reply', function (done) {
+        var nc = NATS.connect({port: PORT, useOldRequestStyle: true});
+        requestOneGetsReply(nc, done);
+    });
+
+    function requestOneWillUnsubscribe(nc, done) {
         var rsub = "x.y.z";
-        var nc = NATS.connect(PORT);
         var count = 0;
 
-        nc.subscribe(rsub, function(msg, reply) {
+        nc.subscribe(rsub, function (msg, reply) {
             reply.should.match(/_INBOX\.*/);
             nc.publish(reply, "y");
             nc.publish(reply, "yy");
             nc.flush();
-            setTimeout(function() {
+            setTimeout(function () {
                 nc.publish(reply, "z");
                 nc.flush();
                 nc.close();
-                setTimeout(function() {
+                setTimeout(function () {
                     count.should.equal(1);
+                    nc.close();
                     done();
                 }, 1000);
             }, 1500);
         });
 
-        nc.requestOne(rsub, "", null, 1000, function(reply) {
+        nc.requestOne(rsub, "", null, 1000, function (reply) {
             reply.should.not.be.instanceof(NATS.NatsError);
             should.exist(reply);
             count++;
         });
+    }
+
+    it('should do requestone-will-unsubscribe', function (done) {
+        // eslint-disable-next-line
+        this.timeout(3000);
+        var nc = NATS.connect(PORT);
+        requestOneWillUnsubscribe(nc, done);
     });
 
+    it('oldRequest: should do requestone-will-unsubscribe', function (done) {
+        // eslint-disable-next-line
+        this.timeout(3000);
+        var nc = NATS.connect({port: PORT, useOldRequestStyle: true});
+        requestOneWillUnsubscribe(nc, done);
+    });
 
-    it('should do requestone-can-timeout', function(done) {
-        var nc = NATS.connect(PORT);
-        nc.requestOne('a.b.c', '', null, 1000, function(reply) {
+    function requestTimeoutTest(nc, done) {
+        nc.requestOne('a.b.c', '', null, 1000, function (reply) {
             should.exist(reply);
             reply.should.be.instanceof(NATS.NatsError);
             reply.should.have.property('code', NATS.REQ_TIMEOUT);
             nc.close();
             done();
         });
+    }
+
+    it('should do requestone-can-timeout', function (done) {
+        var nc = NATS.connect(PORT);
+        requestTimeoutTest(nc, done);
     });
 
+    it('old request one - should do requestone-can-timeout', function (done) {
+        var nc = NATS.connect({port: PORT, useOldRequestStyle: true});
+        requestTimeoutTest(nc, done);
+    });
 
-    it('should unsubscribe when request one timesout', function(done) {
-        // eslint-disable-next-line
-        this.timeout(3000);
-        var nc = NATS.connect(PORT);
-
+    function shouldUnsubscribeWhenRequestOneTimeout(nc, done) {
         var replies = 0;
         var responses = 0;
         // set a subscriber to respond to the request
         nc.subscribe('a.b.c', {
             max: 1
-        }, function(msg, reply) {
-            setTimeout(function() {
+        }, function (msg, reply) {
+            setTimeout(function () {
                 nc.publish(reply, '');
                 nc.flush();
                 replies++;
@@ -422,7 +446,7 @@ describe('Basics', function() {
         });
 
         // request one - we expect a timeout
-        nc.requestOne('a.b.c', '', null, 250, function(reply) {
+        nc.requestOne('a.b.c', '', null, 250, function (reply) {
             reply.should.be.instanceof(NATS.NatsError);
             reply.should.have.property('code', NATS.REQ_TIMEOUT);
             if (!reply.hasOwnProperty('code')) {
@@ -431,10 +455,44 @@ describe('Basics', function() {
         });
 
         // verify reply was sent, but we didn't get it
-        setTimeout(function() {
+        setTimeout(function () {
             should(replies).equal(1);
             should(responses).equal(0);
+            nc.close();
             done();
         }, 1000);
+    }
+
+    it('should unsubscribe when request one timesout', function (done) {
+        // eslint-disable-next-line
+        this.timeout(3000);
+        var nc = NATS.connect(PORT);
+        shouldUnsubscribeWhenRequestOneTimeout(nc, done);
+    });
+
+    it('old requestOne should unsubscribe when request one timesout', function (done) {
+        // eslint-disable-next-line
+        this.timeout(3000);
+        var nc = NATS.connect({port: PORT, useOldRequestStyle: true});
+        shouldUnsubscribeWhenRequestOneTimeout(nc, done);
+    });
+
+    it('requestone has negative sids', function (done) {
+        var nc = NATS.connect(PORT);
+        nc.flush(function() {
+            var sid = nc.requestOne("121.2.13.4", 1000, function(r) {
+                should.fail("got message when it shouldn't have", r);
+            });
+            sid.should.be.number;
+            sid.should.be.below(0);
+
+            // this cancel returns the config
+            var conf = nc.cancelMuxRequest(sid);
+
+            // after cancel it shouldn't exit
+            nc.respmux.requestMap.should.not.have.ownProperty(conf.token);
+            nc.close();
+            done();
+        });
     });
 });

--- a/test/properties.js
+++ b/test/properties.js
@@ -57,6 +57,8 @@ describe('Connection Properties', function() {
         nc.options.should.have.property('reconnect');
         nc.options.should.have.property('maxReconnectAttempts');
         nc.options.should.have.property('reconnectTimeWait');
+        nc.options.should.have.property('useOldRequestStyle');
+        nc.options.useOldRequestStyle.should.equal(false);
     });
 
     it('should have an parsed url', function() {
@@ -76,7 +78,8 @@ describe('Connection Properties', function() {
             'pedantic': true,
             'reconnect': false,
             'maxReconnectAttempts': 22,
-            'reconnectTimeWait': 11
+            'reconnectTimeWait': 11,
+            'useOldRequestStyle': true,
         };
 
         nc = NATS.connect(options);
@@ -88,7 +91,7 @@ describe('Connection Properties', function() {
         nc.options.reconnect.should.equal(false);
         nc.options.maxReconnectAttempts.should.equal(22);
         nc.options.reconnectTimeWait.should.equal(11);
+        nc.options.useOldRequestStyle.should.equal(true);
         nc.close();
     });
-
 });


### PR DESCRIPTION
- Implements 'new' multiplexed request reply via 'requestOne', where a single multiplexed subscription is reused for all requests. Old requestOne behaviour can be used by setting the option `useOldRequestStyle` option to true.

- Fixes argument shifting in oldRequestOne.

