### PR TITLE
FIX #151

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -1302,16 +1302,64 @@ Client.prototype.timeout = function(sid, timeout, expected, callback) {
  * This should be treated as a subscription. You can optionally indicate how many
  * messages you only want to receive using opt_options = {max:N}. Otherwise you
  * will need to unsubscribe to stop the message stream.
+ *
+ * You can also optionally specify the number of milliseconds to wait for the messages
+ * to receive using opt_options = {timeout: N}. When the number of messages specified
+ * is received before a timeout, the subscription auto-cancels. If the number of messages
+ * is not specified, it is the responsability of the client to unsubscribe to prevent
+ * a timeout.
+ *
  * The Subscriber Id is returned.
  *
  * @param {String} subject
  * @param {String} [opt_msg]
  * @param {Object} [opt_options]
  * @param {Function} callback
- * @return {Mixed}
+ * @return {Number}
  * @api public
+ *
+ * The opt_options can have the following properties:
+ * max: the maximum number of messages before auto-cancelling.
+ * timeout: the number of milliseconds to wait for messages. If max is not specified,
+ * caller is responsible to call 'unsubscribe' with the returned subscriber id.
  */
 Client.prototype.request = function(subject, opt_msg, opt_options, callback) {
+    if(this.options.useOldRequestStyle) {
+        return this.oldRequest(subject, opt_msg, opt_options, callback);
+    }
+    if (typeof opt_msg === 'function') {
+        callback = opt_msg;
+        opt_msg = EMPTY;
+        opt_options = null;
+    }
+    if (typeof opt_options === 'function') {
+        callback = opt_options;
+        opt_options = null;
+    }
+
+    opt_options = opt_options || {};
+    var conf = this.initMuxRequestDetails(callback, opt_options.max);
+    this.publish(subject, opt_msg, conf.inbox);
+
+    if(opt_options.timeout) {
+        var client = this;
+        conf.timer = setTimeout(function() {
+            if(conf.callback) {
+                conf.callback(new NatsError(REQ_TIMEOUT_MSG_PREFIX + subject, REQ_TIMEOUT));
+            }
+            client.cancelMuxRequest(conf.token);
+        }, opt_options.timeout);
+    }
+
+    return conf.id;
+};
+
+
+/**
+ * @deprecated
+ * @api private
+ */
+Client.prototype.oldRequest = function(subject, opt_msg, opt_options, callback) {
     if (typeof opt_msg === 'function') {
         callback = opt_msg;
         opt_msg = EMPTY;
@@ -1368,19 +1416,9 @@ Client.prototype.requestOne = function(subject, opt_msg, opt_options, timeout, c
 
     opt_options = opt_options || {};
     opt_options.max = 1;
+    opt_options.timeout = timeout;
 
-    var conf = this.initMuxRequestDetails(callback);
-    this.publish(subject, opt_msg, conf.inbox);
-
-    var client = this;
-    conf.timer = setTimeout(function() {
-        if(conf.callback) {
-            conf.callback(new NatsError(REQ_TIMEOUT_MSG_PREFIX + subject, REQ_TIMEOUT));
-        }
-        client.cancelMuxRequest(conf.token);
-    }, timeout);
-
-    return conf.id;
+    return this.request(subject, opt_msg, opt_options, callback);
 };
 
 /**
@@ -1405,9 +1443,15 @@ Client.prototype.createResponseMux = function() {
         var inbox = createInbox();
         var ginbox = inbox + ".*";
         var sid = this.subscribe(ginbox, function(msg, reply, subject) {
-            var respToken = client.extractToken(subject);
-            var conf = client.cancelMuxRequest(respToken);
+            var token = client.extractToken(subject);
+            var conf = client.getMuxRequestConfig(token);
             if(conf) {
+                if(conf.hasOwnProperty('max_messages')) {
+                    conf.max_messages--;
+                    if (conf.max_messages <= 0) {
+                        client.cancelMuxRequest(token);
+                    }
+                }
                 conf.callback(msg);
             }
         });
@@ -1426,14 +1470,22 @@ Client.prototype.createResponseMux = function() {
  *
  * @api private
  */
-Client.prototype.initMuxRequestDetails = function(callback) {
+Client.prototype.initMuxRequestDetails = function(callback, max_messages) {
     var ginbox = this.createResponseMux();
     var token = nuid.next();
     var inbox = ginbox + '.' + token;
 
     var conf = {token: token, callback: callback, inbox: inbox, id: this.respmux.nextID--};
+    if(max_messages > 0) {
+        conf.max_messages = max_messages;
+    }
+
     this.respmux.requestMap[token] = conf;
     return conf;
+};
+
+Client.prototype.getMuxRequestConfig = function(token) {
+    return this.respmux.requestMap[token];
 };
 
 /**
@@ -1455,7 +1507,6 @@ Client.prototype.cancelMuxRequest = function(token) {
                 }
             }
         }
-
         if (entry) {
             token = entry.token;
         }
@@ -1472,6 +1523,7 @@ Client.prototype.cancelMuxRequest = function(token) {
 };
 
 /**
+ * @deprecated
  * @api private
  */
 Client.prototype.oldRequestOne = function(subject, opt_msg, opt_options, timeout, callback) {

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -1306,7 +1306,7 @@ Client.prototype.timeout = function(sid, timeout, expected, callback) {
  * You can also optionally specify the number of milliseconds to wait for the messages
  * to receive using opt_options = {timeout: N}. When the number of messages specified
  * is received before a timeout, the subscription auto-cancels. If the number of messages
- * is not specified, it is the responsability of the client to unsubscribe to prevent
+ * is not specified, it is the responsibility of the client to unsubscribe to prevent
  * a timeout.
  *
  * The Subscriber Id is returned.
@@ -1317,11 +1317,6 @@ Client.prototype.timeout = function(sid, timeout, expected, callback) {
  * @param {Function} callback
  * @return {Number}
  * @api public
- *
- * The opt_options can have the following properties:
- * max: the maximum number of messages before auto-cancelling.
- * timeout: the number of milliseconds to wait for messages. If max is not specified,
- * caller is responsible to call 'unsubscribe' with the returned subscriber id.
  */
 Client.prototype.request = function(subject, opt_msg, opt_options, callback) {
     if(this.options.useOldRequestStyle) {

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -1345,7 +1345,7 @@ Client.prototype.request = function(subject, opt_msg, opt_options, callback) {
         var client = this;
         conf.timer = setTimeout(function() {
             if(conf.callback) {
-                conf.callback(new NatsError(REQ_TIMEOUT_MSG_PREFIX + subject, REQ_TIMEOUT));
+                conf.callback(new NatsError(REQ_TIMEOUT_MSG_PREFIX + conf.id, REQ_TIMEOUT));
             }
             client.cancelMuxRequest(conf.token);
         }, opt_options.timeout);

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -94,4 +94,39 @@ describe('Timeout and max received events for subscriptions', function() {
             }, 1000);
         });
     });
+
+
+    it('should perform simple timeouts on requests', function(done) {
+        var nc = NATS.connect(PORT);
+        nc.on('connect', function() {
+            nc.request('foo', null, {max: 1, timeout: 1000}, function(err) {
+                err.should.be.instanceof(NATS.NatsError);
+                err.should.have.property('code', NATS.REQ_TIMEOUT);
+                nc.close();
+                done();
+            });
+        });
+    });
+
+    it('should perform simple timeouts on requests without specified number of messages', function(done) {
+        var nc = NATS.connect(PORT);
+        nc.on('connect', function() {
+            nc.subscribe('foo', function(msg, reply) {
+                nc.publish(reply);
+            });
+
+            var responses = 0;
+            nc.request('foo', null, {max: 2, timeout: 1000}, function(err) {
+                if(!err.hasOwnProperty('code')) {
+                    responses++;
+                    return;
+                }
+                responses.should.be.equal(1);
+                err.should.be.instanceof(NATS.NatsError);
+                err.should.have.property('code', NATS.REQ_TIMEOUT);
+                nc.close();
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
Request/Reply uses a mux handler. This enables request-reply to use a single subscription.
