### PR TITLE
[FIX] #204 - the reply subject was not provided to callbacks with the  global inbox.

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -21,7 +21,7 @@ var net = require('net'),
 /**
  * Constants
  */
-var VERSION = '0.8.2',
+var VERSION = '0.8.4',
 
     DEFAULT_PORT = 4222,
     DEFAULT_PRE = 'nats://localhost:',
@@ -1471,7 +1471,7 @@ Client.prototype.createResponseMux = function() {
                     }
                 }
                 if(conf.callback) {
-                    conf.callback(msg);
+                    conf.callback(msg, reply);
                 }
             }
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "0.8.2",
+  "version": "0.8.4",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -39,4 +39,26 @@ describe('Callbacks', function() {
         });
     });
 
+    it('request callbacks have message and reply', function(done) {
+      var nc = NATS.connect(PORT);
+      nc.flush(function() {
+          nc.subscribe("rr", function(msg, reply) {
+              nc.publish(reply, "data", "foo");
+          });
+      });
+
+      nc.flush(function() {
+          nc.requestOne("rr", 5000, function(msg, reply) {
+              if(msg instanceof NATS.NatsError) {
+                  nc.close();
+                  done("Error making request", msg);
+                  return;
+              }
+              msg.should.be.equal("data");
+              reply.should.be.equal("foo");
+              nc.close();
+              done();
+          });
+      });
+    });
 });


### PR DESCRIPTION
-  Matching previous request functionality.
- Additional arguments such as the generated subject, and sid could be provided but because these are internal to the library not sure if this is valuable if that much control is required, likely it should be a regular subscription.