### PR TITLE
Bumped max control line to 1024

### DIFF
--- a/benchmark/pub_perf.js
+++ b/benchmark/pub_perf.js
@@ -1,35 +1,52 @@
 "use strict";
 
-var nats = require('../lib/nats').connect();
+var NATS = require('../lib/nats');
+var nats = NATS.connect();
+var fs = require('fs');
 
 ///////////////////////////////////////
 // Publish Performance
 ///////////////////////////////////////
 
-var loop = 2000000;
+var loop = 1000000;
 var hash = 2500;
 
 console.log('Publish Performance Test');
 
-nats.on('connect', function() {
+nats.on('connect', function () {
 
-    var start = new Date();
+  var start = new Date();
 
-    var invalid2octet = new Buffer('\xc3\x28', 'binary');
+  var invalid2octet = new Buffer('\xc3\x28', 'binary');
 
-    for (var i = 0; i < loop; i++) {
-        nats.publish('test', invalid2octet);
-        //nats.publish('test', 'ok');
-        if (i % hash === 0) {
-            process.stdout.write('+');
-        }
+  for (var i = 0; i < loop; i++) {
+    nats.publish('test', invalid2octet);
+    //nats.publish('test', 'ok');
+    if (i % hash === 0) {
+      process.stdout.write('+');
     }
+  }
 
-    nats.flush(function() {
-        var stop = new Date();
-        var mps = parseInt(loop / ((stop - start) / 1000), 10);
-        console.log('\nPublished at ' + mps + ' msgs/sec');
+  nats.flush(function () {
+    var stop = new Date();
+    var mps = parseInt(loop / ((stop - start) / 1000), 10);
+    log("pub", loop, stop - start);
+    console.log('\nPublished at ' + mps + ' msgs/sec');
+  });
+
+  function log(op, count, time) {
+    if (process.argv.length === 2) {
+      fs.appendFile('pub.csv', [op, count, time, new Date().toDateString(), NATS.version].join(",") + "\n", function (err) {
+        if (err) {
+          console.log(err);
+        }
         process.exit();
-    });
+      });
+    } else {
+      // running for sub test, don't record
+      process.exit();
+    }
+  }
+
 
 });

--- a/benchmark/pub_sub_perf.js
+++ b/benchmark/pub_sub_perf.js
@@ -1,42 +1,53 @@
 "use strict";
 
-var nc1 = require('../lib/nats').connect();
-var nc2 = require('../lib/nats').connect();
+var fs = require('fs');
+var NATS = require('../lib/nats');
+var nc1 = NATS.connect();
+var nc2 = NATS.connect();
 
 ///////////////////////////////////////
 // Publish/Subscribe Performance
 ///////////////////////////////////////
 
-var loop = 2000000;
+var loop = 1000000;
 var hash = 2500;
 
 console.log('Publish/Subscribe Performance Test');
 
-nc1.on('connect', function() {
+nc1.on('connect', function () {
 
-    var received = 0;
-    var start = new Date();
+  var received = 0;
+  var start = new Date();
 
-    nc1.subscribe('test', function() {
-        received += 1;
+  nc1.subscribe('test', function () {
+    received += 1;
 
-        if (received === loop) {
-            var stop = new Date();
-            var mps = parseInt(loop / ((stop - start) / 1000), 10);
-            console.log('\nPublished/Subscribe at ' + mps + ' msgs/sec');
-            console.log('Received ' + received + ' messages');
-            process.exit();
-        }
+    if (received === loop) {
+      var stop = new Date();
+      var mps = parseInt(loop / ((stop - start) / 1000), 10);
+      console.log('\nPublished/Subscribe at ' + mps + ' msgs/sec');
+      console.log('Received ' + received + ' messages');
+      log("pubsub", loop, stop - start);
+    }
+  });
+
+  // Make sure sub is registered
+  nc1.flush(function () {
+    for (var i = 0; i < loop; i++) {
+      nc2.publish('test', 'ok');
+      if (i % hash === 0) {
+        process.stdout.write('+');
+      }
+    }
+  });
+
+  function log(op, count, time) {
+    fs.appendFile('pubsub.csv', [op, count, time, new Date().toDateString(), NATS.version].join(",") + "\n", function (err) {
+      if (err) {
+        console.log(err);
+      }
+      process.exit();
     });
-
-    // Make sure sub is registered
-    nc1.flush(function() {
-        for (var i = 0; i < loop; i++) {
-            nc2.publish('test', 'ok');
-            if (i % hash === 0) {
-                process.stdout.write('+');
-            }
-        }
-    });
+  }
 
 });

--- a/benchmark/reconnect_perf.js
+++ b/benchmark/reconnect_perf.js
@@ -1,14 +1,15 @@
 "use strict";
 
-var nats = require('../lib/nats'),
-    nsc = require('../test/support/nats_server_control');
+var fs = require('fs');
+var NATS = require('../lib/nats'),
+  nsc = require('../test/support/nats_server_control');
 
 
 ///////////////////////////////////////
 // Reconnect Performance
 ///////////////////////////////////////
 
-var loop = 2000000;
+var loop = 1000000;
 var hash = 2500;
 var PORT = 1426;
 var server;
@@ -16,34 +17,43 @@ var start;
 
 console.log('Reconnect Performance Test');
 
-server = nsc.start_server(PORT, function() {
-    var nc = nats.connect({
-        'port': PORT
+server = nsc.start_server(PORT, function () {
+  var nc = NATS.connect({
+    'port': PORT
+  });
+  nc.on('connect', function () {
+    var fun = function () {
+      //do nothing
+    };
+    for (var i = 0; i < loop; i++) {
+      nc.subscribe('test' + i, fun);
+      if (i % hash === 0) {
+        process.stdout.write('+');
+      }
+    }
+    server.kill();
+    server = nsc.start_server(PORT);
+  });
+  nc.on('reconnecting', function () {
+    start = new Date();
+  });
+  nc.on('reconnect', function () {
+    nc.flush(function () {
+      var stop = new Date();
+      var t = stop - start;
+      console.log('\nReconnected in ' + t + ' ms');
+      nc.close();
+      server.kill();
+      log("reconnect", loop, stop - start);
     });
-    nc.on('connect', function() {
-        var fun = function() {
-            //do nothing
-        };
-        for (var i = 0; i < loop; i++) {
-            nc.subscribe('test' + i, fun);
-            if (i % hash === 0) {
-                process.stdout.write('+');
-            }
-        }
-        server.kill();
-        server = nsc.start_server(PORT);
+  });
+
+  function log(op, count, time) {
+    fs.appendFile('reconnect.csv', [op, count, time, new Date().toDateString(), NATS.version].join(",") + "\n", function (err) {
+      if (err) {
+        console.log(err);
+      }
+      process.exit();
     });
-    nc.on('reconnecting', function() {
-        start = new Date();
-    });
-    nc.on('reconnect', function() {
-        nc.flush(function() {
-            var stop = new Date();
-            var t = stop - start;
-            console.log('\nReconnected in ' + t + ' ms');
-            nc.close();
-            server.kill();
-            process.exit();
-        });
-    });
+  }
 });

--- a/benchmark/request_perf.js
+++ b/benchmark/request_perf.js
@@ -1,7 +1,8 @@
 "use strict";
-
-var nc1 = require('../lib/nats').connect();
-var nc2 = require('../lib/nats').connect();
+var fs = require('fs');
+var NATS = require('../lib/nats');
+var nc1 = NATS.connect();
+var nc2 = NATS.connect();
 
 ///////////////////////////////////////
 // Request Performance
@@ -35,13 +36,21 @@ nc1.on('connect', function() {
                     console.log('\n' + rps + ' request-responses/sec');
                     var lat = parseInt(((stop - start) * 1000) / (loop * 2), 10); // Request=2, Reponse=2 RTs
                     console.log('Avg roundtrip latency: ' + lat + ' microseconds');
-                    process.exit();
+                    log("rr", loop, stop-start);
                 } else if (received % hash === 0) {
                     process.stdout.write('+');
                 }
             });
         }
-
     });
+
+  function log(op, count, time) {
+    fs.appendFile('rr.csv', [op, count, time, new Date().toDateString(), NATS.version].join(",") + "\n", function(err) {
+      if(err) {
+        console.log(err);
+      }
+      process.exit();
+    });
+  }
 
 });

--- a/benchmark/sub_perf.js
+++ b/benchmark/sub_perf.js
@@ -1,32 +1,42 @@
 "use strict";
 
-var nats = require('../lib/nats').connect();
+var fs = require('fs');
+var NATS = require('../lib/nats');
+var nats = NATS.connect();
 
 ///////////////////////////////////////
 // Subscribe Performance
 ///////////////////////////////////////
 
 var start;
-var loop = 500000;
+var loop = 1000000;
 var hash = 2500;
 var received = 0;
 
 console.log('Subscribe Performance Test');
 console.log("Waiting on %d messages", loop);
 
-nats.subscribe('test', function() {
-    received += 1;
-    if (received === 1) {
-        start = new Date();
-    }
-    if (received === loop) {
-        var stop = new Date();
-        console.log('\nDone test');
-        var mps = parseInt(loop / ((stop - start) / 1000), 10);
-        console.log('Received at ' + mps + ' msgs/sec');
-        process.exit();
-    } else if (received % hash === 0) {
-        process.stdout.write('+');
-    }
+nats.subscribe('test', function () {
+  received += 1;
+  if (received === 1) {
+    start = new Date();
+  }
+  if (received === loop) {
+    var stop = new Date();
+    console.log('\nDone test');
+    var mps = parseInt(loop / ((stop - start) / 1000), 10);
+    console.log('Received at ' + mps + ' msgs/sec');
+    log("sub", loop, stop-start);
+  } else if (received % hash === 0) {
+    process.stdout.write('+');
+  }
 
+  function log(op, count, time) {
+      fs.appendFile('sub.csv', [op, count, time, new Date().toDateString(), NATS.version].join(",") + "\n", function (err) {
+        if (err) {
+          console.log(err);
+        }
+        process.exit();
+      });
+  }
 });

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -29,13 +29,13 @@ var net = require('net'),
 /**
  * Constants
  */
-var VERSION = '0.8.6',
+var VERSION = '0.8.8',
 
     DEFAULT_PORT = 4222,
     DEFAULT_PRE = 'nats://localhost:',
     DEFAULT_URI = DEFAULT_PRE + DEFAULT_PORT,
 
-    MAX_CONTROL_LINE_SIZE = 512,
+    MAX_CONTROL_LINE_SIZE = 1024,
 
     // Parser state
     AWAITING_CONTROL = 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "0.8.6",
+  "version": "0.8.8",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",
@@ -41,7 +41,7 @@
     "node": ">= 0.10.x"
   },
   "dependencies": {
-    "nuid": ">=0.6.8"
+    "nuid": ">=0.6.14"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
[FIX] #169 - Bumped max control line to 1024

Modified bench tests to save the output to csv file for comparison, for multi-run:
`seq 1…0 | xargs -I -- node testname.js`
