### PR TITLE
Clamping versions of nuid and node.

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -29,7 +29,7 @@ var net = require('net'),
 /**
  * Constants
  */
-var VERSION = '0.8.8',
+var VERSION = '0.8.10',
 
     DEFAULT_PORT = 4222,
     DEFAULT_PRE = 'nats://localhost:',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "0.8.8",
+  "version": "0.8.10",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",
@@ -38,10 +38,10 @@
     "fmt": "js-beautify -n --config crockford.jscsrc -r lib/* test/*.js test/support/*.js examples/* benchmark/*.js"
   },
   "engines": {
-    "node": ">= 0.10.x"
+    "node": ">= 0.10.x <10.0.0"
   },
   "dependencies": {
-    "nuid": ">=0.6.14"
+    "nuid": "^0.6.14"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
This is to ensure that there's an alternative for someone running in an old version of node.