### PR TITLE
Add missing TypeScript property definitions on ClientOpts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -80,7 +80,11 @@ export interface ClientOpts {
 	yieldTime?: number,
 	waitOnFirstConnect?: boolean,
 	json?: boolean,
-	preserveBuffers?: boolean
+	preserveBuffers?: boolean,
+	token?: string,
+	pintInterval?: number,
+	maxPingOut?: number,
+	useOldRequestStyle?: boolean
 }
 
 export interface SubscribeOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,7 +82,7 @@ export interface ClientOpts {
 	json?: boolean,
 	preserveBuffers?: boolean,
 	token?: string,
-	pintInterval?: number,
+	pingInterval?: number,
 	maxPingOut?: number,
 	useOldRequestStyle?: boolean
 }


### PR DESCRIPTION
Hi Team,

I've been using the node.js/TypeScript client and noticed there are some missing params on connect. I checked these against the variable names used in assignOption so hopefully all is correct.

Cheers,
Chris