### PR TITLE
[FIX] #229 - set stream.setNoDelay(true) 

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -29,7 +29,7 @@ var net = require('net'),
 /**
  * Constants
  */
-var VERSION = '1.0.0',
+var VERSION = '1.0.1',
 
     DEFAULT_PORT = 4222,
     DEFAULT_PRE = 'nats://localhost:',
@@ -619,6 +619,8 @@ Client.prototype.createConnection = function() {
     }
     // Create the stream
     this.stream = net.createConnection(this.url.port, this.url.hostname);
+    // this change makes it a bit faster on Linux, slightly worse on OS X
+    this.stream.setNoDelay(true);
     // Setup the proper handlers.
     this.setupHandlers();
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",


### PR DESCRIPTION
This change is better for Linux, slightly worse for OS X.

```
PUB
version           average   max   min   samples  rate
----------------  --------  ----  ----  -------  ----------------
1.0.0_tcpnodelay  1050.125  1079  1041  1000000  952,267 msgs/sec
1.0.0             1073.25   1103  1052  1000000  931,749 msgs/sec

PUBSUB
version           average            max   min   samples  rate
----------------  -----------------  ----  ----  -------  ----------------
1.0.0_tcpnodelay  1794.142857142857  1828  1762  1000000  557,369 msgs/sec
1.0.0             1843.375           1859  1818  1000000  542,483 msgs/sec
```