### PR TITLE
gnatsd 1.2.0 requires the client to check info values before initiating a TLS connection.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ git:
   depth: false
 
 env:
-  - NATS_VERSION=v1.0.6
+  - NATS_VERSION=v1.2.0
 
 before_script:
   - wget "https://github.com/nats-io/gnatsd/releases/download/$NATS_VERSION/gnatsd-$NATS_VERSION-linux-amd64.zip" -O tmp.zip

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -388,8 +388,7 @@ Client.prototype.checkTLSMismatch = function() {
         return true;
     }
 
-    if (this.info.tls_required === false &&
-        this.options.tls !== false) {
+    if (!this.info.tls_required && this.options.tls !== false) {
         this.emit('error', new NatsError(NON_SECURE_CONN_REQ_MSG, NON_SECURE_CONN_REQ));
         this.closeStream();
         return true;


### PR DESCRIPTION
[FIX] Attempting to connect via TLS on a server that doesn't have TLS available (as reported by the INFO), now results in a different error. Fixed a check where we verify if the info tls_required is set.

Bumped travis gnatsd to 1.2.0