### PR TITLE
FIX #261 TypeScript bindings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ export const STALE_CONNECTION_ERR: string;
 
 /**
  * Create a properly formatted inbox subject.
-*/
+ */
 export function createInbox(): string;
 
 /**
@@ -113,9 +113,8 @@ declare class Client extends events.EventEmitter {
 	/**
 	 * Publish a message to the given subject, with optional reply and callback.
 	 */
-	publish(callback: Function):void;
-	publish(subject: string, callback: Function):void;
-	publish(subject: string, msg: any, callback: Function):void;
+	publish(subject: string, callback?: Function):void;
+	publish(subject: string, msg: any, callback?: Function):void;
 	publish(subject: string, msg: any, reply: string, callback?: Function):void;
 
 	/**
@@ -126,7 +125,7 @@ declare class Client extends events.EventEmitter {
 	subscribe(subject: string, opts: SubscribeOptions, callback: Function): number;
 
 	/**
-	 * Unsubscribe to a given Subscriber Id, with optional max parameter.
+	 * Unsubscribe to a given Subscriber Id, with optional max number of messages before unsubscribing.
 	 */
 	unsubscribe(sid: number, max?: number):void;
 
@@ -154,7 +153,9 @@ declare class Client extends events.EventEmitter {
 	 * a timeout has been reached.
 	 * The Subscriber Id is returned.
 	 */
-	requestOne(subject: string, msg: any, options: SubscribeOptions, timeout: number, callback?:Function) : number
+	requestOne(subject: string, timeout: number, callback: Function);
+	requestOne(subject: string, msg: any, timeout: number, callback: Function);
+	requestOne(subject: string, msg: any, options: SubscribeOptions, timeout: number, callback: Function);
 
 	/**
 	 * Report number of outstanding subscriptions on this connection.
@@ -163,10 +164,10 @@ declare class Client extends events.EventEmitter {
 }
 
 declare class NatsError implements Error {
-    public name: string;
-    public message: string;
-    public code: string;
-    public chainedError: Error;
+	public name: string;
+	public message: string;
+	public code: string;
+	public chainedError: Error;
 
-    constructor(message:string, code:string, chainedError?:Error);
+	constructor(message:string, code:string, chainedError?:Error);
 }

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -32,7 +32,7 @@ const net = require('net'),
 /**
  * Constants
  */
-const VERSION = '1.2.6',
+const VERSION = '1.2.8',
 
     DEFAULT_PORT = 4222,
     DEFAULT_PRE = 'nats://localhost:',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "1.2.6",
+  "version": "1.2.8",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",


### PR DESCRIPTION
Contributed bindings were not exactly right. Fixed the typescript bindings to show the actual arguments that are required. Optional signature in typescript makes a previous argument required, but the library actually does argument shifting so the exploded signatures are the correct representation.

- removed a bad publish signature without a subject, but with callback
- clarified the publish with explicit arguments - really only optional argument given the three forms is the optional callback. Note the library does argument shifting so the exact forms are the expected.
- fixed requestOne signatures, to reflect that subject, timeout and callback are required.