### PR TITLE
Port tokenHandler mechanism from go-nats (option processInbound())

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -79,6 +79,9 @@ const VERSION = '1.2.10',
     // Errors
     BAD_AUTHENTICATION = 'BAD_AUTHENTICATION',
     BAD_AUTHENTICATION_MSG = 'User and Token can not both be provided',
+    BAD_AUTHENTICATION_TH_NOT_FUNC_MSG = 'tokenHandler must be a function returning accepting a callback',
+    BAD_AUTHENTICATION_T_AND_TH_MSG = 'token and tokenHandler cannot both be provided',
+    BAD_AUTHENTICATION_TH_FAILED_MSG_PREFIX = 'tokenHandler call failed: ',
     BAD_JSON = 'BAD_JSON',
     BAD_JSON_MSG = 'Message should be a non-circular JSON-serializable value',
     BAD_MSG = 'BAD_MSG',
@@ -282,6 +285,7 @@ Client.prototype.parseOptions = function(opts) {
         this.assignOption(opts, 'user');
         this.assignOption(opts, 'pass');
         this.assignOption(opts, 'token');
+        this.assignOption(opts, 'tokenHandler');
         this.assignOption(opts, 'password', 'pass');
         this.assignOption(opts, 'verbose');
         this.assignOption(opts, 'pedantic');
@@ -326,10 +330,19 @@ Client.prototype.parseOptions = function(opts) {
 
     // Set token as needed if in options.
     this.token = options.token;
+    this.tokenHandler = options.tokenHandler;
 
     // Authentication - make sure authentication is valid.
     if (this.user && this.token) {
         throw (new NatsError(BAD_AUTHENTICATION_MSG, BAD_AUTHENTICATION));
+    }
+
+    if (this.tokenHandler && (typeof this.tokenHandler !== 'function' || this.tokenHandler.length !== 1)) {
+        throw (new NatsError(BAD_AUTHENTICATION_TH_NOT_FUNC_MSG, BAD_AUTHENTICATION));
+    }
+
+    if (this.tokenHandler && this.token) {
+        throw (new NatsError(BAD_AUTHENTICATION_T_AND_TH_MSG, BAD_AUTHENTICATION));
     }
 
     // Encoding - make sure its valid.
@@ -753,7 +766,7 @@ Client.prototype.sendConnect = function() {
         cs.user = this.user;
         cs.pass = this.pass;
     }
-    if (this.token !== undefined) {
+    if (this.token) {
         cs.auth_token = this.token;
     }
     if (this.options.name !== undefined) {
@@ -1136,19 +1149,21 @@ Client.prototype.processInbound = function() {
                             this.setupHandlers();
                         }
 
-                        // Send the connect message and subscriptions immediately
-                        this.sendConnect();
-                        this.sendSubscriptions();
-
-                        this.pongs.unshift(() => {
-                            this.connectCB();
-                        });
-                        this.stream.write(PING_REQUEST);
-
-                        // Mark as received
-                        this.infoReceived = true;
-                        this.stripPendingSubs();
-                        this.flushPending();
+                        if (this.tokenHandler) {
+                            this.tokenHandler((err, token) => {
+                                if (err) {
+                                    this.token = null;
+                                    this.emit('error', new NatsError(BAD_AUTHENTICATION_TH_FAILED_MSG_PREFIX + err, BAD_AUTHENTICATION, err));
+                                } else {
+                                    this.token = token;
+                                }
+                                this.completeInfoReceived();
+                            });
+                        } else {
+                            setImmediate(() => {
+                                this.completeInfoReceived();
+                            });
+                        }
                     }
                 } else {
                     // FIXME, check line length for something weird.
@@ -1237,6 +1252,26 @@ Client.prototype.processInbound = function() {
         }
         m = null;
     }
+};
+
+/**
+ * Send connect, subscription, PING_REQUEST, and mark INFO received
+ * @api private
+ */
+Client.prototype.completeInfoReceived = function() {
+    // Send the connect message and subscriptions immediately
+    this.sendConnect();
+    this.sendSubscriptions();
+
+    this.pongs.unshift(() => {
+        this.connectCB();
+    });
+    this.stream.write(PING_REQUEST);
+
+    // Mark as received
+    this.infoReceived = true;
+    this.stripPendingSubs();
+    this.flushPending();
 };
 
 /**

--- a/test/auth.js
+++ b/test/auth.js
@@ -100,7 +100,7 @@ describe('Token Authorization', function() {
 
     // Shutdown our server after we are done
     after(function(done) {
-        server = nsc.stop_server(server, done);
+        nsc.stop_server(server, done);
     });
 
     it('should fail to connect with no credentials ', function(done) {
@@ -143,6 +143,161 @@ describe('Token Authorization', function() {
         nc.on('connect', function(nc) {
             nc.close();
             setTimeout(done, 100);
+        });
+    });
+});
+
+describe('tokenHandler Authorization', function() {
+    const PORT = 1421;
+    const flags = ['--auth', 'token1'];
+    const noAuthUrl = 'nats://localhost:' + PORT;
+    let server;
+
+    // Start up our own nats-server
+    before(function(done) {
+        server = nsc.start_server(PORT, flags, done);
+    });
+
+    // Shutdown our server after we are done
+    after(function(done) {
+        nsc.stop_server(server, done);
+    });
+
+    it('should connect using tokenHandler instead of plain old token', function(done) {
+        const nc = NATS.connect({
+            'url': noAuthUrl,
+            'tokenHandler': (callback) => {
+                setTimeout(() => {
+                    callback(null, 'token1');
+                }, 500);
+            }
+        });
+        nc.on('connect', (nc) => {
+            setTimeout(() => {
+                nc.close();
+                done();
+            }, 100);
+        });
+    });
+
+    it('should fail to connect if tokenHandler is not a function', function(done) {
+        (function() {
+            const nc = NATS.connect({
+                'url': noAuthUrl,
+                'tokenHandler': 'token1'
+            });
+        }).should.throw(/tokenHandler must be a function returning accepting a callback/);
+        done();
+    });
+
+    it('should fail to connect if tokenHandler is not a function accepting exactly 1 argument', function(done) {
+        (function() {
+            const nc = NATS.connect({
+                'url': noAuthUrl,
+                'tokenHandler': function() {}
+            });
+        }).should.throw(/tokenHandler must be a function returning accepting a callback/);
+        (function() {
+            const nc = NATS.connect({
+                'url': noAuthUrl,
+                'tokenHandler': function(a, b) {}
+            });
+        }).should.throw(/tokenHandler must be a function returning accepting a callback/);
+        done();
+    });
+
+    it('should fail to connect if both token and tokenHandler are provided', function(done) {
+        (function() {
+            const nc = NATS.connect({
+                'url': noAuthUrl,
+                'token': 'token1',
+                'tokenHandler': (callback) => {
+                    setTimeout(() => {
+                        callback(null, 'token1');
+                    }, 500);
+                }
+            });
+        }).should.throw(/token and tokenHandler cannot both be provided/);
+        done();
+    });
+
+    it('should NOT connect if tokenHandler fails to return a token', function(done) {
+        const nc = NATS.connect({
+            'url': noAuthUrl,
+            'tokenHandler': (callback) => {
+                setTimeout(() => {
+                    callback(new Error('no token for you!'));
+                }, 50);
+            }
+        });
+
+        let totalErrorCount = 0;
+        let tokenHandlerErrorCount = 0;
+        let authorizationViolationErrorCount = 0;
+        let disconnectCount = 0;
+        nc.on('error', (err) => {
+            totalErrorCount++;
+            if ((/^NatsError: tokenHandler call failed: .+$/).test(err.toString())) {
+                tokenHandlerErrorCount++;
+            }
+            if ((/^NatsError: 'Authorization Violation'$/).test(err.toString())) {
+                authorizationViolationErrorCount++;
+            }
+        });
+        nc.on('disconnect', () => {
+            disconnectCount++;
+        });
+        nc.on('close', () => {
+            tokenHandlerErrorCount.should.be.greaterThan(0);
+            authorizationViolationErrorCount.should.equal(tokenHandlerErrorCount);
+            totalErrorCount.should.be.greaterThanOrEqual(2 * tokenHandlerErrorCount);
+
+            disconnectCount.should.equal(tokenHandlerErrorCount);
+            done();
+        });
+    });
+
+    it('tokenHandler errors can be recovered from', function(done) {
+        this.timeout(10 * 1000);
+
+        let tokenHandlerCallCount = 0;
+        const nc = NATS.connect({
+            'url': noAuthUrl,
+            'tokenHandler': (callback) => {
+                tokenHandlerCallCount++;
+                setTimeout(() => {
+                    if (tokenHandlerCallCount == 2) {
+                        callback(new Error('no token for you!'));
+                    } else {
+                        callback(null, 'token1');
+                    }
+                }, 50);
+            }
+        });
+
+        let totalErrorCount = 0;
+        let tokenHandlerErrorCount = 0;
+        nc.on('error', (err) => {
+            totalErrorCount++;
+            if ((/^NatsError: tokenHandler call failed: .+$/).test(err.toString())) {
+                tokenHandlerErrorCount++;
+            }
+        });
+        nc.on('connect', () => {
+            setTimeout(() => {
+                nsc.stop_server(server, () => {
+                    server = nsc.start_server(PORT, flags);
+                });
+            }, 100);
+        });
+        nc.on('reconnect', (nc) => {
+            setTimeout(() => {
+                nc.close();
+                tokenHandlerCallCount.should.equal(3);
+                tokenHandlerErrorCount.should.equal(1);
+                totalErrorCount.should.be.greaterThan(tokenHandlerErrorCount);
+                done();
+            }, 100);
         });
     });
 });


### PR DESCRIPTION
Fixes: #265 

# Description

I wasn't sure of the best place to plug this in. This PR introduces the code directly in `processInbound()`, which is very close to how it's done in `go-nats`.