### PR TITLE
Port tokenHandler mechanism from go-nats (option createConnection())

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -79,6 +79,9 @@ const VERSION = '1.2.10',
     // Errors
     BAD_AUTHENTICATION = 'BAD_AUTHENTICATION',
     BAD_AUTHENTICATION_MSG = 'User and Token can not both be provided',
+    BAD_AUTHENTICATION_TH_NOT_FUNC_MSG = 'tokenHandler must be a function returning a Promise',
+    BAD_AUTHENTICATION_T_AND_TH_MSG = 'token and tokenHandler cannot both be provided',
+    BAD_AUTHENTICATION_TH_FAILED_MSG_PREFIX = 'tokenHandler call failed: ',
     BAD_JSON = 'BAD_JSON',
     BAD_JSON_MSG = 'Message should be a non-circular JSON-serializable value',
     BAD_MSG = 'BAD_MSG',
@@ -282,6 +285,7 @@ Client.prototype.parseOptions = function(opts) {
         this.assignOption(opts, 'user');
         this.assignOption(opts, 'pass');
         this.assignOption(opts, 'token');
+        this.assignOption(opts, 'tokenHandler');
         this.assignOption(opts, 'password', 'pass');
         this.assignOption(opts, 'verbose');
         this.assignOption(opts, 'pedantic');
@@ -326,10 +330,19 @@ Client.prototype.parseOptions = function(opts) {
 
     // Set token as needed if in options.
     this.token = options.token;
+    this.tokenHandler = options.tokenHandler;
 
     // Authentication - make sure authentication is valid.
     if (this.user && this.token) {
         throw (new NatsError(BAD_AUTHENTICATION_MSG, BAD_AUTHENTICATION));
+    }
+
+    if (this.tokenHandler && (typeof this.tokenHandler !== 'function')) {
+        throw (new NatsError(BAD_AUTHENTICATION_TH_NOT_FUNC_MSG, BAD_AUTHENTICATION));
+    }
+
+    if (this.tokenHandler && this.token) {
+        throw (new NatsError(BAD_AUTHENTICATION_T_AND_TH_MSG, BAD_AUTHENTICATION));
     }
 
     // Encoding - make sure its valid.
@@ -645,6 +658,27 @@ Client.prototype.scheduleHeartbeat = function() {
 };
 
 /**
+ * Schedule a reconnect if configured, else close
+ *
+ * @api private
+ */
+Client.prototype.reconnectOrClose = function() {
+    const stream = this.stream;
+    this.closeStream();
+    if (stream && stream.bytesRead > 0) {
+        this.emit('disconnect');
+    }
+    if (this.closed === true ||
+        this.options.reconnect === false ||
+        ((this.reconnects >= this.options.maxReconnectAttempts) && this.options.maxReconnectAttempts !== -1)) {
+        this.cleanupTimers();
+        this.emit('close');
+    } else {
+        this.scheduleReconnect();
+    }
+};
+
+/**
  * Properly setup a stream event handlers.
  *
  * @api private
@@ -662,19 +696,8 @@ Client.prototype.setupHandlers = function() {
         this.scheduleHeartbeat();
     });
 
-    stream.on('close', (hadError) => {
-        this.closeStream();
-        if(stream.bytesRead > 0) {
-            this.emit('disconnect');
-        }
-        if (this.closed === true ||
-            this.options.reconnect === false ||
-            ((this.reconnects >= this.options.maxReconnectAttempts) && this.options.maxReconnectAttempts !== -1)) {
-            this.cleanupTimers();
-            this.emit('close');
-        } else {
-            this.scheduleReconnect();
-        }
+    stream.on('close', () => {
+        this.reconnectOrClose();
     });
 
     stream.on('error', (exception) => {
@@ -827,13 +850,31 @@ Client.prototype.createConnection = function() {
     if (this.stream) {
         this.stream.removeAllListeners();
         this.stream.destroy();
+        this.stream = null;
     }
-    // Create the stream
-    this.stream = net.createConnection(this.url.port, this.url.hostname);
-    // this change makes it a bit faster on Linux, slightly worse on OS X
-    this.stream.setNoDelay(true);
-    // Setup the proper handlers.
-    this.setupHandlers();
+
+    const doCreateConnection = () => {
+        // Create the stream
+        this.stream = net.createConnection(this.url.port, this.url.hostname);
+        // this change makes it a bit faster on Linux, slightly worse on OS X
+        this.stream.setNoDelay(true);
+        // Setup the proper handlers.
+        this.setupHandlers();
+    };
+
+    if (this.tokenHandler) {
+        this.tokenHandler().then((token) => {
+            this.token = token;
+            doCreateConnection();
+        }, (err) => {
+            this.emit('error', new NatsError(BAD_AUTHENTICATION_TH_FAILED_MSG_PREFIX + err, BAD_AUTHENTICATION, err));
+            setImmediate(() => {
+                this.reconnectOrClose();
+            });
+        });
+    } else {
+        doCreateConnection();
+    }
 };
 
 /**
@@ -905,7 +946,7 @@ Client.prototype.cleanupTimers = function() {
  * @api private
  */
 Client.prototype.closeStream = function() {
-    if (this.stream !== null) {
+    if (this.stream) {
         this.stream.destroy();
         this.stream = null;
     }


### PR DESCRIPTION
Fixes: #265 

# Description

I wasn't sure of the best place to plug this in. This PR introduces the code into `createConnection()`. It might work well there because it wouldn't be "interrupting" an otherwise synchronous flow inside the `processInbound()`. However, it moves the call to obtain the token a bit further from where it would be used. This solution also assumes that the auth is only ever done on a fresh TCP connection. Is this assumption correct?  