### PR TITLE
Port tokenHandler mechanism from go-nats (option synchronous)

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -79,6 +79,9 @@ const VERSION = '1.2.10',
     // Errors
     BAD_AUTHENTICATION = 'BAD_AUTHENTICATION',
     BAD_AUTHENTICATION_MSG = 'User and Token can not both be provided',
+    BAD_AUTHENTICATION_TH_NOT_FUNC_MSG = 'tokenHandler must be a function returning a token',
+    BAD_AUTHENTICATION_T_AND_TH_MSG = 'token and tokenHandler cannot both be provided',
+    BAD_AUTHENTICATION_TH_FAILED_MSG_PREFIX = 'tokenHandler call failed: ',
     BAD_JSON = 'BAD_JSON',
     BAD_JSON_MSG = 'Message should be a non-circular JSON-serializable value',
     BAD_MSG = 'BAD_MSG',
@@ -282,6 +285,7 @@ Client.prototype.parseOptions = function(opts) {
         this.assignOption(opts, 'user');
         this.assignOption(opts, 'pass');
         this.assignOption(opts, 'token');
+        this.assignOption(opts, 'tokenHandler');
         this.assignOption(opts, 'password', 'pass');
         this.assignOption(opts, 'verbose');
         this.assignOption(opts, 'pedantic');
@@ -326,10 +330,19 @@ Client.prototype.parseOptions = function(opts) {
 
     // Set token as needed if in options.
     this.token = options.token;
+    this.tokenHandler = options.tokenHandler;
 
     // Authentication - make sure authentication is valid.
     if (this.user && this.token) {
         throw (new NatsError(BAD_AUTHENTICATION_MSG, BAD_AUTHENTICATION));
+    }
+
+    if (this.tokenHandler && typeof this.tokenHandler !== 'function') {
+        throw (new NatsError(BAD_AUTHENTICATION_TH_NOT_FUNC_MSG, BAD_AUTHENTICATION));
+    }
+
+    if (this.tokenHandler && this.token) {
+        throw (new NatsError(BAD_AUTHENTICATION_T_AND_TH_MSG, BAD_AUTHENTICATION));
     }
 
     // Encoding - make sure its valid.
@@ -753,7 +766,15 @@ Client.prototype.sendConnect = function() {
         cs.user = this.user;
         cs.pass = this.pass;
     }
-    if (this.token !== undefined) {
+    if (this.tokenHandler !== undefined) {
+        let token;
+        try {
+            token = this.tokenHandler();
+        } catch (err) {
+            this.emit('error', new NatsError(BAD_AUTHENTICATION_TH_FAILED_MSG_PREFIX + err, BAD_AUTHENTICATION, err));
+        }
+        cs.auth_token = token;
+    } else if (this.token !== undefined) {
         cs.auth_token = this.token;
     }
     if (this.options.name !== undefined) {


### PR DESCRIPTION
Fixes: #265 

# Description

This PR introduces the hook directly into the `sendConnect()` as a synchronous call. This is more or less exactly how it's done in `go-nats`.